### PR TITLE
release: v0.0.3

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
           cache: true
       - name: Build
         run: go build -v ./...
@@ -39,7 +39,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18
+        go-version: 1.19
         cache: true
     - name: Build
       run: go build -v ./...
@@ -59,13 +59,19 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18
+        go-version: 1.19
 
     - name: Build
       run: go build -v ./...
 
     - name: Test
       run: go test -v ./...
+
+    - name: Install govulncheck
+      run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
+    - name: Run govulncheck
+      run: govulncheck ./...
 
   create-release:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v0.0.3
+
+### [0.0.3](https://github.com/openfga/go-sdk/compare/v0.0.2...v0.0.3) (2022-09-07)
+
+- Fix incorrectly applying client_credentials validation to api_token cred method [openfga/sdk-generator#21](https://github.com/openfga/sdk-generator/pull/21)
+- Target go 1.19
+- Bump golang.org/x/net
+- Use [govulncheck](https://go.dev/blog/vuln) in CI to check for issues
+
 ## v0.0.2
 
 ### [0.0.2](https://github.com/openfga/go-sdk/compare/v0.0.1...v0.0.2) (2022-08-15)

--- a/configuration.go
+++ b/configuration.go
@@ -19,7 +19,7 @@ import (
 	"github.com/openfga/go-sdk/credentials"
 )
 
-var SdkVersion = "0.0.2"
+var SdkVersion = "0.0.3"
 
 // RetryParams configures configuration for retry in case of HTTP too many request
 type RetryParams struct {

--- a/credentials/credentials.go
+++ b/credentials/credentials.go
@@ -70,7 +70,7 @@ func (c *Credentials) ValidateCredentialsConfig() error {
     conf := c.Config
     if c.Method == CredentialsMethodApiToken && (conf == nil || conf.ApiToken == "") {
         return fmt.Errorf("CredentialsConfig.ApiToken is required when CredentialsMethod is CredentialsMethodApiToken (%s)", c.Method)
-    } else if c.Method == CredentialsMethodApiToken {
+    } else if c.Method == CredentialsMethodClientCredentials {
         if conf == nil ||
             conf.ClientCredentialsClientId == "" ||
             conf.ClientCredentialsClientSecret == "" ||

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/openfga/go-sdk
 
-go 1.18
+go 1.19
 
 require (
 	github.com/jarcoal/httpmock v1.2.0
-	golang.org/x/net v0.0.0-20220812174116-3211cb980234
+	golang.org/x/net v0.0.0-20220907135653-1e95f45603a7
 )

--- a/go.sum
+++ b/go.sum
@@ -2,5 +2,5 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/jarcoal/httpmock v1.2.0 h1:gSvTxxFR/MEMfsGrvRbdfpRUMBStovlSRLw0Ep1bwwc=
 github.com/jarcoal/httpmock v1.2.0/go.mod h1:oCoTsnAz4+UoOUIf5lJOWV2QQIW5UoeUI6aM2YnWAZk=
 github.com/maxatome/go-testdeep v1.11.0 h1:Tgh5efyCYyJFGUYiT0qxBSIDeXw0F5zSoatlou685kk=
-golang.org/x/net v0.0.0-20220812174116-3211cb980234 h1:RDqmgfe7SvlMWoqC3xwQ2blLO3fcWcxMa3eBLRdRW7E=
-golang.org/x/net v0.0.0-20220812174116-3211cb980234/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
+golang.org/x/net v0.0.0-20220907135653-1e95f45603a7 h1:1WGATo9HAhkWMbfyuVU0tEFP88OIkUvwaHFveQPvzCQ=
+golang.org/x/net v0.0.0-20220907135653-1e95f45603a7/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=


### PR DESCRIPTION
- Fix incorrectly applying client_credentials validation to api_token cred method [openfga/sdk-generator#21](https://github.com/openfga/sdk-generator/pull/21)
- Target go 1.19
- Bump golang.org/x/net
- Use [govulncheck](https://go.dev/blog/vuln) in CI to check for issues