### PR TITLE
fix: allow empty string as ulid

### DIFF
--- a/api_open_fga.go
+++ b/api_open_fga.go
@@ -673,7 +673,7 @@ func (a *OpenFgaApiService) CheckExecute(r ApiCheckRequest) (CheckResponse, *_ne
 		if a.client.cfg.StoreId == "" {
 			return localVarReturnValue, nil, reportError("Configuration.StoreId is required and must be specified to call this method")
 		}
-		if !internalutils.IsWellFormedUlidString(a.client.cfg.StoreId) {
+		if a.client.cfg.StoreId != "" && !internalutils.IsWellFormedUlidString(a.client.cfg.StoreId) {
 			return localVarReturnValue, nil, reportError("Configuration.StoreId is invalid")
 		}
 		localVarPath := "/stores/{store_id}/check"
@@ -1193,7 +1193,7 @@ func (a *OpenFgaApiService) DeleteStoreExecute(r ApiDeleteStoreRequest) (*_netht
 		if a.client.cfg.StoreId == "" {
 			return nil, reportError("Configuration.StoreId is required and must be specified to call this method")
 		}
-		if !internalutils.IsWellFormedUlidString(a.client.cfg.StoreId) {
+		if a.client.cfg.StoreId != "" && !internalutils.IsWellFormedUlidString(a.client.cfg.StoreId) {
 			return nil, reportError("Configuration.StoreId is invalid")
 		}
 		localVarPath := "/stores/{store_id}"
@@ -1499,7 +1499,7 @@ func (a *OpenFgaApiService) ExpandExecute(r ApiExpandRequest) (ExpandResponse, *
 		if a.client.cfg.StoreId == "" {
 			return localVarReturnValue, nil, reportError("Configuration.StoreId is required and must be specified to call this method")
 		}
-		if !internalutils.IsWellFormedUlidString(a.client.cfg.StoreId) {
+		if a.client.cfg.StoreId != "" && !internalutils.IsWellFormedUlidString(a.client.cfg.StoreId) {
 			return localVarReturnValue, nil, reportError("Configuration.StoreId is invalid")
 		}
 		localVarPath := "/stores/{store_id}/expand"
@@ -1760,7 +1760,7 @@ func (a *OpenFgaApiService) GetStoreExecute(r ApiGetStoreRequest) (GetStoreRespo
 		if a.client.cfg.StoreId == "" {
 			return localVarReturnValue, nil, reportError("Configuration.StoreId is required and must be specified to call this method")
 		}
-		if !internalutils.IsWellFormedUlidString(a.client.cfg.StoreId) {
+		if a.client.cfg.StoreId != "" && !internalutils.IsWellFormedUlidString(a.client.cfg.StoreId) {
 			return localVarReturnValue, nil, reportError("Configuration.StoreId is invalid")
 		}
 		localVarPath := "/stores/{store_id}"
@@ -2030,7 +2030,7 @@ func (a *OpenFgaApiService) ListObjectsExecute(r ApiListObjectsRequest) (ListObj
 		if a.client.cfg.StoreId == "" {
 			return localVarReturnValue, nil, reportError("Configuration.StoreId is required and must be specified to call this method")
 		}
-		if !internalutils.IsWellFormedUlidString(a.client.cfg.StoreId) {
+		if a.client.cfg.StoreId != "" && !internalutils.IsWellFormedUlidString(a.client.cfg.StoreId) {
 			return localVarReturnValue, nil, reportError("Configuration.StoreId is invalid")
 		}
 		localVarPath := "/stores/{store_id}/list-objects"
@@ -2669,7 +2669,7 @@ func (a *OpenFgaApiService) ReadExecute(r ApiReadRequest) (ReadResponse, *_netht
 		if a.client.cfg.StoreId == "" {
 			return localVarReturnValue, nil, reportError("Configuration.StoreId is required and must be specified to call this method")
 		}
-		if !internalutils.IsWellFormedUlidString(a.client.cfg.StoreId) {
+		if a.client.cfg.StoreId != "" && !internalutils.IsWellFormedUlidString(a.client.cfg.StoreId) {
 			return localVarReturnValue, nil, reportError("Configuration.StoreId is invalid")
 		}
 		localVarPath := "/stores/{store_id}/read"
@@ -2934,7 +2934,7 @@ func (a *OpenFgaApiService) ReadAssertionsExecute(r ApiReadAssertionsRequest) (R
 		if a.client.cfg.StoreId == "" {
 			return localVarReturnValue, nil, reportError("Configuration.StoreId is required and must be specified to call this method")
 		}
-		if !internalutils.IsWellFormedUlidString(a.client.cfg.StoreId) {
+		if a.client.cfg.StoreId != "" && !internalutils.IsWellFormedUlidString(a.client.cfg.StoreId) {
 			return localVarReturnValue, nil, reportError("Configuration.StoreId is invalid")
 		}
 		localVarPath := "/stores/{store_id}/assertions/{authorization_model_id}"
@@ -3238,7 +3238,7 @@ func (a *OpenFgaApiService) ReadAuthorizationModelExecute(r ApiReadAuthorization
 		if a.client.cfg.StoreId == "" {
 			return localVarReturnValue, nil, reportError("Configuration.StoreId is required and must be specified to call this method")
 		}
-		if !internalutils.IsWellFormedUlidString(a.client.cfg.StoreId) {
+		if a.client.cfg.StoreId != "" && !internalutils.IsWellFormedUlidString(a.client.cfg.StoreId) {
 			return localVarReturnValue, nil, reportError("Configuration.StoreId is invalid")
 		}
 		localVarPath := "/stores/{store_id}/authorization-models/{id}"
@@ -3547,7 +3547,7 @@ func (a *OpenFgaApiService) ReadAuthorizationModelsExecute(r ApiReadAuthorizatio
 		if a.client.cfg.StoreId == "" {
 			return localVarReturnValue, nil, reportError("Configuration.StoreId is required and must be specified to call this method")
 		}
-		if !internalutils.IsWellFormedUlidString(a.client.cfg.StoreId) {
+		if a.client.cfg.StoreId != "" && !internalutils.IsWellFormedUlidString(a.client.cfg.StoreId) {
 			return localVarReturnValue, nil, reportError("Configuration.StoreId is invalid")
 		}
 		localVarPath := "/stores/{store_id}/authorization-models"
@@ -3829,7 +3829,7 @@ func (a *OpenFgaApiService) ReadChangesExecute(r ApiReadChangesRequest) (ReadCha
 		if a.client.cfg.StoreId == "" {
 			return localVarReturnValue, nil, reportError("Configuration.StoreId is required and must be specified to call this method")
 		}
-		if !internalutils.IsWellFormedUlidString(a.client.cfg.StoreId) {
+		if a.client.cfg.StoreId != "" && !internalutils.IsWellFormedUlidString(a.client.cfg.StoreId) {
 			return localVarReturnValue, nil, reportError("Configuration.StoreId is invalid")
 		}
 		localVarPath := "/stores/{store_id}/changes"
@@ -4141,7 +4141,7 @@ func (a *OpenFgaApiService) WriteExecute(r ApiWriteRequest) (map[string]interfac
 		if a.client.cfg.StoreId == "" {
 			return localVarReturnValue, nil, reportError("Configuration.StoreId is required and must be specified to call this method")
 		}
-		if !internalutils.IsWellFormedUlidString(a.client.cfg.StoreId) {
+		if a.client.cfg.StoreId != "" && !internalutils.IsWellFormedUlidString(a.client.cfg.StoreId) {
 			return localVarReturnValue, nil, reportError("Configuration.StoreId is invalid")
 		}
 		localVarPath := "/stores/{store_id}/write"
@@ -4410,7 +4410,7 @@ func (a *OpenFgaApiService) WriteAssertionsExecute(r ApiWriteAssertionsRequest) 
 		if a.client.cfg.StoreId == "" {
 			return nil, reportError("Configuration.StoreId is required and must be specified to call this method")
 		}
-		if !internalutils.IsWellFormedUlidString(a.client.cfg.StoreId) {
+		if a.client.cfg.StoreId != "" && !internalutils.IsWellFormedUlidString(a.client.cfg.StoreId) {
 			return nil, reportError("Configuration.StoreId is invalid")
 		}
 		localVarPath := "/stores/{store_id}/assertions/{authorization_model_id}"
@@ -4714,7 +4714,7 @@ func (a *OpenFgaApiService) WriteAuthorizationModelExecute(r ApiWriteAuthorizati
 		if a.client.cfg.StoreId == "" {
 			return localVarReturnValue, nil, reportError("Configuration.StoreId is required and must be specified to call this method")
 		}
-		if !internalutils.IsWellFormedUlidString(a.client.cfg.StoreId) {
+		if a.client.cfg.StoreId != "" && !internalutils.IsWellFormedUlidString(a.client.cfg.StoreId) {
 			return localVarReturnValue, nil, reportError("Configuration.StoreId is invalid")
 		}
 		localVarPath := "/stores/{store_id}/authorization-models"

--- a/client/client.go
+++ b/client/client.go
@@ -87,7 +87,7 @@ func NewSdkClient(cfg *ClientConfiguration) (*OpenFgaClient, error) {
 
 	// store id is already validate as part of configuration validation
 
-	if cfg.AuthorizationModelId != nil && !internalutils.IsWellFormedUlidString(*cfg.AuthorizationModelId) {
+	if cfg.AuthorizationModelId != nil && *cfg.AuthorizationModelId != "" && !internalutils.IsWellFormedUlidString(*cfg.AuthorizationModelId) {
 		return nil, FgaInvalidError{param: "AuthorizationModelId", description: "ULID"}
 	}
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -50,6 +50,16 @@ func TestOpenFgaClient(t *testing.T) {
 		}
 	})
 
+	t.Run("Allow client to have empty store ID specified", func(t *testing.T) {
+		_, err := NewSdkClient(&ClientConfiguration{
+			ApiHost: "api.fga.example",
+			StoreId: "",
+		})
+		if err != nil {
+			t.Fatalf("Expect no error when store id is empty but has %v", err)
+		}
+	})
+
 	t.Run("Validate store ID when specified", func(t *testing.T) {
 		_, err := NewSdkClient(&ClientConfiguration{
 			ApiHost: "api.fga.example",
@@ -68,6 +78,17 @@ func TestOpenFgaClient(t *testing.T) {
 		})
 		if err == nil {
 			t.Fatalf("Expect invalid auth mode ID to result in error but there is none")
+		}
+	})
+
+	t.Run("Allow auth model ID to be empty when specified", func(t *testing.T) {
+		_, err := NewSdkClient(&ClientConfiguration{
+			ApiHost:              "api.fga.example",
+			StoreId:              "01GXSB9YR785C4FYS3C0RTG7B2",
+			AuthorizationModelId: openfga.PtrString(""),
+		})
+		if err != nil {
+			t.Fatalf("Expect no error when auth model id is empty but has %v", err)
 		}
 	})
 


### PR DESCRIPTION
## Description
Allow empty string for store id and auth model id

## References
Close https://github.com/openfga/go-sdk/issues/36

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [X] The correct base branch is being used, if not `main`
- [X] I have added tests to validate that the change in functionality is working as expected
