### PR TITLE
fix: client option + body not respected

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -487,11 +487,11 @@ func (client *OpenFgaClient) ListStoresExecute(request SdkClientListStoresReques
 	req := client.OpenFgaApi.ListStores(request.GetContext())
 	pageSize := getPageSizeFromRequest((*ClientPaginationOptions)(request.GetOptions()))
 	if pageSize != nil {
-		req.PageSize(*pageSize)
+		req = req.PageSize(*pageSize)
 	}
 	continuationToken := getContinuationTokenFromRequest((*ClientPaginationOptions)(request.GetOptions()))
 	if continuationToken != nil {
-		req.ContinuationToken(*continuationToken)
+		req = req.ContinuationToken(*continuationToken)
 	}
 	data, _, err := req.Execute()
 	if err != nil {
@@ -730,11 +730,11 @@ func (client *OpenFgaClient) ReadAuthorizationModelsExecute(request SdkClientRea
 	req := client.OpenFgaApi.ReadAuthorizationModels(request.GetContext())
 	pageSize := getPageSizeFromRequest((*ClientPaginationOptions)(request.GetOptions()))
 	if pageSize != nil {
-		req.PageSize(*pageSize)
+		req = req.PageSize(*pageSize)
 	}
 	continuationToken := getContinuationTokenFromRequest((*ClientPaginationOptions)(request.GetOptions()))
 	if continuationToken != nil {
-		req.ContinuationToken(*continuationToken)
+		req = req.ContinuationToken(*continuationToken)
 	}
 	data, _, err := req.Execute()
 	if err != nil {
@@ -890,7 +890,7 @@ func (client *OpenFgaClient) ReadAuthorizationModelExecute(request SdkClientRead
 	if err != nil {
 		return nil, err
 	}
-	if authorizationModelId == nil {
+	if authorizationModelId == nil || *authorizationModelId == "" {
 		return nil, FgaRequiredParamError{param: "AuthorizationModelId"}
 	}
 	data, _, err := client.OpenFgaApi.ReadAuthorizationModel(request.GetContext(), *authorizationModelId).Execute()
@@ -1040,12 +1040,17 @@ func (client *OpenFgaClient) ReadChangesExecute(request SdkClientReadChangesRequ
 	req := client.OpenFgaApi.ReadChanges(request.GetContext())
 	pageSize := getPageSizeFromRequest((*ClientPaginationOptions)(request.GetOptions()))
 	if pageSize != nil {
-		req.PageSize(*pageSize)
+		req = req.PageSize(*pageSize)
 	}
 	continuationToken := getContinuationTokenFromRequest((*ClientPaginationOptions)(request.GetOptions()))
 	if continuationToken != nil {
-		req.ContinuationToken(*continuationToken)
+		req = req.ContinuationToken(*continuationToken)
 	}
+	requestBody := request.GetBody()
+	if requestBody != nil {
+		req = req.Type_(requestBody.Type)
+	}
+
 	data, _, err := req.Execute()
 	if err != nil {
 		return nil, err
@@ -1487,7 +1492,7 @@ func (client *OpenFgaClient) WriteTuplesExecute(request SdkClientWriteTuplesRequ
 		Writes: request.GetBody(),
 	})
 	if request.GetOptions() != nil {
-		baseReq.Options(*request.GetOptions())
+		baseReq = baseReq.Options(*request.GetOptions())
 	}
 	return baseReq.Execute()
 }
@@ -1551,7 +1556,7 @@ func (client *OpenFgaClient) DeleteTuplesExecute(request SdkClientDeleteTuplesRe
 		Deletes: request.GetBody(),
 	})
 	if request.GetOptions() != nil {
-		baseReq.Options(*request.GetOptions())
+		baseReq = baseReq.Options(*request.GetOptions())
 	}
 	return baseReq.Execute()
 }
@@ -2155,7 +2160,7 @@ func (client *OpenFgaClient) ReadAssertionsExecute(request SdkClientReadAssertio
 	if err != nil {
 		return nil, err
 	}
-	if authorizationModelId == nil {
+	if authorizationModelId == nil || *authorizationModelId == "" {
 		return nil, FgaRequiredParamError{param: "AuthorizationModelId"}
 	}
 	data, _, err := client.OpenFgaApi.ReadAssertions(request.GetContext(), *authorizationModelId).Execute()
@@ -2258,7 +2263,7 @@ func (client *OpenFgaClient) WriteAssertionsExecute(request SdkClientWriteAssert
 	if err != nil {
 		return nil, err
 	}
-	if authorizationModelId == nil {
+	if authorizationModelId == nil || *authorizationModelId == "" {
 		return nil, FgaRequiredParamError{param: "AuthorizationModelId"}
 	}
 	for index := 0; index < len(*request.GetBody()); index++ {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -499,9 +499,17 @@ func TestOpenFgaClient(t *testing.T) {
 		if *(*got.AuthorizationModel).Id != modelId {
 			t.Fatalf("OpenFgaClient.%v() = %v, want %v", test.Name, string(responseJson), test.JsonResponse)
 		}
-		// ReadAuthorizationModel without options should work
+		// ReadAuthorizationModel without options should not work
 		_, err = fgaClient.ReadAuthorizationModel(context.Background()).Execute()
 		expectedError := "Required parameter AuthorizationModelId was not provided"
+		if err == nil || err.Error() != expectedError {
+			t.Fatalf("Expected error:%v, got: %v", expectedError, err)
+		}
+		// ReadAuthorizationModel with options of empty string should not work
+		badOptions := ClientReadAuthorizationModelOptions{
+			AuthorizationModelId: openfga.PtrString(""),
+		}
+		_, err = fgaClient.ReadAuthorizationModel(context.Background()).Options(badOptions).Execute()
 		if err == nil || err.Error() != expectedError {
 			t.Fatalf("Expected error:%v, got: %v", expectedError, err)
 		}


### PR DESCRIPTION
## Description
Client not taking in details for option and body in list stores/read changes etc. In addition, read auth model does not check and error when auth model is id string is empty



## References
Close https://github.com/openfga/go-sdk/issues/41
Close https://github.com/openfga/go-sdk/issues/42


## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
