### PR TITLE
BREAKING CHANGE: drop UserAgent

### DIFF
--- a/api_client.go
+++ b/api_client.go
@@ -60,7 +60,7 @@ type service struct {
 	RetryParams *RetryParams
 }
 
-// NewAPIClient creates a new API client. Requires a userAgent string describing your application.
+// NewAPIClient creates a new API client.
 // optionally a custom http.Client to allow for advanced features such as caching.
 func NewAPIClient(cfg *Configuration) *APIClient {
 	if cfg.HTTPClient == nil {
@@ -280,9 +280,6 @@ func (c *APIClient) prepareRequest(
 		}
 		localVarRequest.Header = headers
 	}
-
-	// Add the user agent to the request.
-	localVarRequest.Header.Set("User-Agent", c.cfg.UserAgent)
 
 	for header, value := range c.cfg.DefaultHeaders {
 		localVarRequest.Header.Set(header, value)

--- a/client/client.go
+++ b/client/client.go
@@ -19,9 +19,9 @@ import (
 	"math"
 	_nethttp "net/http"
 
-	"github.com/openfga/go-sdk"
+	openfga "github.com/openfga/go-sdk"
 	"github.com/openfga/go-sdk/credentials"
-	"github.com/openfga/go-sdk/internal/utils"
+	internalutils "github.com/openfga/go-sdk/internal/utils"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -41,7 +41,6 @@ type ClientConfiguration struct {
 	AuthorizationModelId *string                  `json:"authorization_model_id,omitempty"`
 	Credentials          *credentials.Credentials `json:"credentials,omitempty"`
 	DefaultHeaders       map[string]string        `json:"default_headers,omitempty"`
-	UserAgent            string                   `json:"user_agent,omitempty"`
 	Debug                bool                     `json:"debug,omitempty"`
 	HTTPClient           *_nethttp.Client
 	RetryParams          *openfga.RetryParams
@@ -54,7 +53,6 @@ func newClientConfiguration(cfg *openfga.Configuration) ClientConfiguration {
 		StoreId:        cfg.StoreId,
 		Credentials:    cfg.Credentials,
 		DefaultHeaders: cfg.DefaultHeaders,
-		UserAgent:      cfg.UserAgent,
 		Debug:          cfg.Debug,
 		RetryParams:    cfg.RetryParams,
 	}
@@ -73,7 +71,6 @@ func NewSdkClient(cfg *ClientConfiguration) (*OpenFgaClient, error) {
 		StoreId:        cfg.StoreId,
 		Credentials:    cfg.Credentials,
 		DefaultHeaders: cfg.DefaultHeaders,
-		UserAgent:      cfg.UserAgent,
 		Debug:          cfg.Debug,
 		RetryParams:    cfg.RetryParams,
 	})

--- a/configuration.go
+++ b/configuration.go
@@ -16,13 +16,11 @@ import (
 	"net/http"
 
 	"github.com/openfga/go-sdk/credentials"
-	"github.com/openfga/go-sdk/internal/utils"
+	internalutils "github.com/openfga/go-sdk/internal/utils"
 )
 
 const (
 	SdkVersion = "0.2.2"
-
-	defaultUserAgent = "openfga-sdk go/0.2.2"
 )
 
 // RetryParams configures configuration for retry in case of HTTP too many request
@@ -38,7 +36,6 @@ type Configuration struct {
 	StoreId        string                   `json:"store_id,omitempty"`
 	Credentials    *credentials.Credentials `json:"credentials,omitempty"`
 	DefaultHeaders map[string]string        `json:"default_headers,omitempty"`
-	UserAgent      string                   `json:"user_agent,omitempty"`
 	Debug          bool                     `json:"debug,omitempty"`
 	HTTPClient     *http.Client
 	RetryParams    *RetryParams
@@ -52,10 +49,6 @@ func DefaultRetryParams() *RetryParams {
 	}
 }
 
-func GetSdkUserAgent() string {
-	return defaultUserAgent
-}
-
 // NewConfiguration returns a new Configuration object
 func NewConfiguration(config Configuration) (*Configuration, error) {
 	cfg := &Configuration{
@@ -64,17 +57,12 @@ func NewConfiguration(config Configuration) (*Configuration, error) {
 		StoreId:        config.StoreId,
 		Credentials:    config.Credentials,
 		DefaultHeaders: config.DefaultHeaders,
-		UserAgent:      config.UserAgent,
 		Debug:          false,
 		RetryParams:    config.RetryParams,
 	}
 
 	if cfg.ApiScheme == "" {
 		cfg.ApiScheme = "https"
-	}
-
-	if cfg.UserAgent == "" {
-		cfg.UserAgent = GetSdkUserAgent()
 	}
 
 	if cfg.DefaultHeaders == nil {


### PR DESCRIPTION
It is not used in the OpenFGA server anywhere.

## Description
Dropping an unused header in the OpenFGA server.

## References
[The OpenFGA server code](https://github.com/openfga/openfga). `grep -r 'User-Agent'` there gives nothing.

## Review Checklist
- [X] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [X] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [X] The correct base branch is being used, if not `main`
- [X] I have added tests to validate that the change in functionality is working as expected
