### PR TITLE
feat: oauth2 client credentials support

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ func main() {
 }
 ```
 
-#### Client Credentials
+#### Auth0 Client Credentials
 
 ```golang
 import (
@@ -171,6 +171,38 @@ func main() {
                 ClientCredentialsClientId:       os.Getenv("FGA_CLIENT_ID"),
                 ClientCredentialsClientSecret:   os.Getenv("FGA_CLIENT_SECRET"),
                 ClientCredentialsApiAudience:    os.Getenv("FGA_API_AUDIENCE"),
+                ClientCredentialsApiTokenIssuer: os.Getenv("FGA_API_TOKEN_ISSUER"),
+            },
+        },
+    })
+
+    if err != nil {
+        // .. Handle error
+    }
+}
+```
+
+#### OAuth2 Client Credentials
+
+```golang
+import (
+    openfga "github.com/openfga/go-sdk"
+    . "github.com/openfga/go-sdk/client"
+    "github.com/openfga/go-sdk/credentials"
+    "os"
+)
+
+func main() {
+    fgaClient, err := NewSdkClient(&ClientConfiguration{
+        ApiUrl:               os.Getenv("FGA_API_URL"), // required, e.g. https://api.fga.example
+        StoreId:              os.Getenv("FGA_STORE_ID"), // not needed when calling `CreateStore` or `ListStores`
+        AuthorizationModelId: os.Getenv("FGA_AUTHORIZATION_MODEL_ID"), // optional, recommended to be set for production
+        Credentials: &credentials.Credentials{
+            Method: credentials.CredentialsMethodClientCredentials,
+            Config: &credentials.Config{
+                ClientCredentialsClientId:       os.Getenv("FGA_CLIENT_ID"),
+                ClientCredentialsClientSecret:   os.Getenv("FGA_CLIENT_SECRET"),
+                ClientCredentialsScopes:         os.Getenv("FGA_API_SCOPES"), // optional space separated scopes
                 ClientCredentialsApiTokenIssuer: os.Getenv("FGA_API_TOKEN_ISSUER"),
             },
         },


### PR DESCRIPTION
Add OAuth2 client credentials support

## Description
Add an optional scope parameter and make the audience parameter optional.

## References
https://github.com/openfga/sdk-generator/issues/255
https://github.com/openfga/sdk-generator/pull/256

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
