### PR TITLE
fix: remove canonical import path from oauth2 packages

### DIFF
--- a/oauth2/clientcredentials/clientcredentials.go
+++ b/oauth2/clientcredentials/clientcredentials.go
@@ -11,7 +11,7 @@
 // server.
 //
 // See https://tools.ietf.org/html/rfc6749#section-4.4
-package clientcredentials // import "golang.org/x/oauth2/clientcredentials"
+package clientcredentials
 
 import (
 	"context"

--- a/oauth2/oauth2.go
+++ b/oauth2/oauth2.go
@@ -6,7 +6,7 @@
 // OAuth2 authorized and authenticated HTTP requests,
 // as specified in RFC 6749.
 // It can additionally grant authorization with Bearer JWT.
-package oauth2 // import "golang.org/x/oauth2"
+package oauth2
 
 import (
 	"bytes"


### PR DESCRIPTION

remove canonical imports from oauth2 packages

## Description


## References

https://github.com/openfga/go-sdk/issues/63

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
