### PR TITLE
fix: dont escape HTML characters in conditions

### DIFF
--- a/model_aborted_message_response.go
+++ b/model_aborted_message_response.go
@@ -13,6 +13,8 @@
 package openfga
 
 import (
+	"bytes"
+
 	"encoding/json"
 )
 
@@ -111,7 +113,14 @@ func (o AbortedMessageResponse) MarshalJSON() ([]byte, error) {
 	if o.Message != nil {
 		toSerialize["message"] = o.Message
 	}
-	return json.Marshal(toSerialize)
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(toSerialize)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 type NullableAbortedMessageResponse struct {

--- a/model_any.go
+++ b/model_any.go
@@ -13,6 +13,8 @@
 package openfga
 
 import (
+	"bytes"
+
 	"encoding/json"
 )
 
@@ -75,7 +77,14 @@ func (o Any) MarshalJSON() ([]byte, error) {
 	if o.Type != nil {
 		toSerialize["@type"] = o.Type
 	}
-	return json.Marshal(toSerialize)
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(toSerialize)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 type NullableAny struct {

--- a/model_assertion.go
+++ b/model_assertion.go
@@ -13,6 +13,8 @@
 package openfga
 
 import (
+	"bytes"
+
 	"encoding/json"
 )
 
@@ -93,7 +95,14 @@ func (o Assertion) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["tuple_key"] = o.TupleKey
 	toSerialize["expectation"] = o.Expectation
-	return json.Marshal(toSerialize)
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(toSerialize)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 type NullableAssertion struct {

--- a/model_assertion_tuple_key.go
+++ b/model_assertion_tuple_key.go
@@ -13,6 +13,8 @@
 package openfga
 
 import (
+	"bytes"
+
 	"encoding/json"
 )
 
@@ -120,7 +122,14 @@ func (o AssertionTupleKey) MarshalJSON() ([]byte, error) {
 	toSerialize["object"] = o.Object
 	toSerialize["relation"] = o.Relation
 	toSerialize["user"] = o.User
-	return json.Marshal(toSerialize)
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(toSerialize)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 type NullableAssertionTupleKey struct {

--- a/model_authorization_model.go
+++ b/model_authorization_model.go
@@ -13,6 +13,8 @@
 package openfga
 
 import (
+	"bytes"
+
 	"encoding/json"
 )
 
@@ -156,7 +158,14 @@ func (o AuthorizationModel) MarshalJSON() ([]byte, error) {
 	if o.Conditions != nil {
 		toSerialize["conditions"] = o.Conditions
 	}
-	return json.Marshal(toSerialize)
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(toSerialize)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 type NullableAuthorizationModel struct {

--- a/model_check_request.go
+++ b/model_check_request.go
@@ -13,6 +13,8 @@
 package openfga
 
 import (
+	"bytes"
+
 	"encoding/json"
 )
 
@@ -212,7 +214,14 @@ func (o CheckRequest) MarshalJSON() ([]byte, error) {
 	if o.Context != nil {
 		toSerialize["context"] = o.Context
 	}
-	return json.Marshal(toSerialize)
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(toSerialize)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 type NullableCheckRequest struct {

--- a/model_check_request_tuple_key.go
+++ b/model_check_request_tuple_key.go
@@ -13,6 +13,8 @@
 package openfga
 
 import (
+	"bytes"
+
 	"encoding/json"
 )
 
@@ -120,7 +122,14 @@ func (o CheckRequestTupleKey) MarshalJSON() ([]byte, error) {
 	toSerialize["user"] = o.User
 	toSerialize["relation"] = o.Relation
 	toSerialize["object"] = o.Object
-	return json.Marshal(toSerialize)
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(toSerialize)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 type NullableCheckRequestTupleKey struct {

--- a/model_check_response.go
+++ b/model_check_response.go
@@ -13,6 +13,8 @@
 package openfga
 
 import (
+	"bytes"
+
 	"encoding/json"
 )
 
@@ -112,7 +114,14 @@ func (o CheckResponse) MarshalJSON() ([]byte, error) {
 	if o.Resolution != nil {
 		toSerialize["resolution"] = o.Resolution
 	}
-	return json.Marshal(toSerialize)
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(toSerialize)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 type NullableCheckResponse struct {

--- a/model_computed.go
+++ b/model_computed.go
@@ -13,6 +13,8 @@
 package openfga
 
 import (
+	"bytes"
+
 	"encoding/json"
 )
 
@@ -66,7 +68,14 @@ func (o *Computed) SetUserset(v string) {
 func (o Computed) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["userset"] = o.Userset
-	return json.Marshal(toSerialize)
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(toSerialize)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 type NullableComputed struct {

--- a/model_condition.go
+++ b/model_condition.go
@@ -13,6 +13,8 @@
 package openfga
 
 import (
+	"bytes"
+
 	"encoding/json"
 )
 
@@ -131,7 +133,14 @@ func (o Condition) MarshalJSON() ([]byte, error) {
 	if o.Parameters != nil {
 		toSerialize["parameters"] = o.Parameters
 	}
-	return json.Marshal(toSerialize)
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(toSerialize)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 type NullableCondition struct {

--- a/model_condition_param_type_ref.go
+++ b/model_condition_param_type_ref.go
@@ -13,6 +13,8 @@
 package openfga
 
 import (
+	"bytes"
+
 	"encoding/json"
 )
 
@@ -104,7 +106,14 @@ func (o ConditionParamTypeRef) MarshalJSON() ([]byte, error) {
 	if o.GenericTypes != nil {
 		toSerialize["generic_types"] = o.GenericTypes
 	}
-	return json.Marshal(toSerialize)
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(toSerialize)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 type NullableConditionParamTypeRef struct {

--- a/model_contextual_tuple_keys.go
+++ b/model_contextual_tuple_keys.go
@@ -13,6 +13,8 @@
 package openfga
 
 import (
+	"bytes"
+
 	"encoding/json"
 )
 
@@ -66,7 +68,14 @@ func (o *ContextualTupleKeys) SetTupleKeys(v []TupleKey) {
 func (o ContextualTupleKeys) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["tuple_keys"] = o.TupleKeys
-	return json.Marshal(toSerialize)
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(toSerialize)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 type NullableContextualTupleKeys struct {

--- a/model_create_store_request.go
+++ b/model_create_store_request.go
@@ -13,6 +13,8 @@
 package openfga
 
 import (
+	"bytes"
+
 	"encoding/json"
 )
 
@@ -66,7 +68,14 @@ func (o *CreateStoreRequest) SetName(v string) {
 func (o CreateStoreRequest) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["name"] = o.Name
-	return json.Marshal(toSerialize)
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(toSerialize)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 type NullableCreateStoreRequest struct {

--- a/model_create_store_response.go
+++ b/model_create_store_response.go
@@ -13,6 +13,8 @@
 package openfga
 
 import (
+	"bytes"
+
 	"encoding/json"
 	"time"
 )
@@ -148,7 +150,14 @@ func (o CreateStoreResponse) MarshalJSON() ([]byte, error) {
 	toSerialize["name"] = o.Name
 	toSerialize["created_at"] = o.CreatedAt
 	toSerialize["updated_at"] = o.UpdatedAt
-	return json.Marshal(toSerialize)
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(toSerialize)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 type NullableCreateStoreResponse struct {

--- a/model_difference.go
+++ b/model_difference.go
@@ -13,6 +13,8 @@
 package openfga
 
 import (
+	"bytes"
+
 	"encoding/json"
 )
 
@@ -93,7 +95,14 @@ func (o Difference) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["base"] = o.Base
 	toSerialize["subtract"] = o.Subtract
-	return json.Marshal(toSerialize)
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(toSerialize)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 type NullableDifference struct {

--- a/model_expand_request.go
+++ b/model_expand_request.go
@@ -13,6 +13,8 @@
 package openfga
 
 import (
+	"bytes"
+
 	"encoding/json"
 )
 
@@ -102,7 +104,14 @@ func (o ExpandRequest) MarshalJSON() ([]byte, error) {
 	if o.AuthorizationModelId != nil {
 		toSerialize["authorization_model_id"] = o.AuthorizationModelId
 	}
-	return json.Marshal(toSerialize)
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(toSerialize)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 type NullableExpandRequest struct {

--- a/model_expand_request_tuple_key.go
+++ b/model_expand_request_tuple_key.go
@@ -13,6 +13,8 @@
 package openfga
 
 import (
+	"bytes"
+
 	"encoding/json"
 )
 
@@ -93,7 +95,14 @@ func (o ExpandRequestTupleKey) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["relation"] = o.Relation
 	toSerialize["object"] = o.Object
-	return json.Marshal(toSerialize)
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(toSerialize)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 type NullableExpandRequestTupleKey struct {

--- a/model_expand_response.go
+++ b/model_expand_response.go
@@ -13,6 +13,8 @@
 package openfga
 
 import (
+	"bytes"
+
 	"encoding/json"
 )
 
@@ -75,7 +77,14 @@ func (o ExpandResponse) MarshalJSON() ([]byte, error) {
 	if o.Tree != nil {
 		toSerialize["tree"] = o.Tree
 	}
-	return json.Marshal(toSerialize)
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(toSerialize)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 type NullableExpandResponse struct {

--- a/model_get_store_response.go
+++ b/model_get_store_response.go
@@ -13,6 +13,8 @@
 package openfga
 
 import (
+	"bytes"
+
 	"encoding/json"
 	"time"
 )
@@ -184,7 +186,14 @@ func (o GetStoreResponse) MarshalJSON() ([]byte, error) {
 	if o.DeletedAt != nil {
 		toSerialize["deleted_at"] = o.DeletedAt
 	}
-	return json.Marshal(toSerialize)
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(toSerialize)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 type NullableGetStoreResponse struct {

--- a/model_internal_error_message_response.go
+++ b/model_internal_error_message_response.go
@@ -13,6 +13,8 @@
 package openfga
 
 import (
+	"bytes"
+
 	"encoding/json"
 )
 
@@ -115,7 +117,14 @@ func (o InternalErrorMessageResponse) MarshalJSON() ([]byte, error) {
 	if o.Message != nil {
 		toSerialize["message"] = o.Message
 	}
-	return json.Marshal(toSerialize)
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(toSerialize)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 type NullableInternalErrorMessageResponse struct {

--- a/model_leaf.go
+++ b/model_leaf.go
@@ -13,6 +13,8 @@
 package openfga
 
 import (
+	"bytes"
+
 	"encoding/json"
 )
 
@@ -147,7 +149,14 @@ func (o Leaf) MarshalJSON() ([]byte, error) {
 	if o.TupleToUserset != nil {
 		toSerialize["tupleToUserset"] = o.TupleToUserset
 	}
-	return json.Marshal(toSerialize)
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(toSerialize)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 type NullableLeaf struct {

--- a/model_list_objects_request.go
+++ b/model_list_objects_request.go
@@ -13,6 +13,8 @@
 package openfga
 
 import (
+	"bytes"
+
 	"encoding/json"
 )
 
@@ -229,7 +231,14 @@ func (o ListObjectsRequest) MarshalJSON() ([]byte, error) {
 	if o.Context != nil {
 		toSerialize["context"] = o.Context
 	}
-	return json.Marshal(toSerialize)
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(toSerialize)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 type NullableListObjectsRequest struct {

--- a/model_list_objects_response.go
+++ b/model_list_objects_response.go
@@ -13,6 +13,8 @@
 package openfga
 
 import (
+	"bytes"
+
 	"encoding/json"
 )
 
@@ -66,7 +68,14 @@ func (o *ListObjectsResponse) SetObjects(v []string) {
 func (o ListObjectsResponse) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["objects"] = o.Objects
-	return json.Marshal(toSerialize)
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(toSerialize)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 type NullableListObjectsResponse struct {

--- a/model_list_stores_response.go
+++ b/model_list_stores_response.go
@@ -13,6 +13,8 @@
 package openfga
 
 import (
+	"bytes"
+
 	"encoding/json"
 )
 
@@ -94,7 +96,14 @@ func (o ListStoresResponse) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["stores"] = o.Stores
 	toSerialize["continuation_token"] = o.ContinuationToken
-	return json.Marshal(toSerialize)
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(toSerialize)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 type NullableListStoresResponse struct {

--- a/model_metadata.go
+++ b/model_metadata.go
@@ -13,6 +13,8 @@
 package openfga
 
 import (
+	"bytes"
+
 	"encoding/json"
 )
 
@@ -75,7 +77,14 @@ func (o Metadata) MarshalJSON() ([]byte, error) {
 	if o.Relations != nil {
 		toSerialize["relations"] = o.Relations
 	}
-	return json.Marshal(toSerialize)
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(toSerialize)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 type NullableMetadata struct {

--- a/model_node.go
+++ b/model_node.go
@@ -13,6 +13,8 @@
 package openfga
 
 import (
+	"bytes"
+
 	"encoding/json"
 )
 
@@ -210,7 +212,14 @@ func (o Node) MarshalJSON() ([]byte, error) {
 	if o.Intersection != nil {
 		toSerialize["intersection"] = o.Intersection
 	}
-	return json.Marshal(toSerialize)
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(toSerialize)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 type NullableNode struct {

--- a/model_nodes.go
+++ b/model_nodes.go
@@ -13,6 +13,8 @@
 package openfga
 
 import (
+	"bytes"
+
 	"encoding/json"
 )
 
@@ -66,7 +68,14 @@ func (o *Nodes) SetNodes(v []Node) {
 func (o Nodes) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["nodes"] = o.Nodes
-	return json.Marshal(toSerialize)
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(toSerialize)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 type NullableNodes struct {

--- a/model_object_relation.go
+++ b/model_object_relation.go
@@ -13,6 +13,8 @@
 package openfga
 
 import (
+	"bytes"
+
 	"encoding/json"
 )
 
@@ -111,7 +113,14 @@ func (o ObjectRelation) MarshalJSON() ([]byte, error) {
 	if o.Relation != nil {
 		toSerialize["relation"] = o.Relation
 	}
-	return json.Marshal(toSerialize)
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(toSerialize)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 type NullableObjectRelation struct {

--- a/model_path_unknown_error_message_response.go
+++ b/model_path_unknown_error_message_response.go
@@ -13,6 +13,8 @@
 package openfga
 
 import (
+	"bytes"
+
 	"encoding/json"
 )
 
@@ -115,7 +117,14 @@ func (o PathUnknownErrorMessageResponse) MarshalJSON() ([]byte, error) {
 	if o.Message != nil {
 		toSerialize["message"] = o.Message
 	}
-	return json.Marshal(toSerialize)
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(toSerialize)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 type NullablePathUnknownErrorMessageResponse struct {

--- a/model_read_assertions_response.go
+++ b/model_read_assertions_response.go
@@ -13,6 +13,8 @@
 package openfga
 
 import (
+	"bytes"
+
 	"encoding/json"
 )
 
@@ -102,7 +104,14 @@ func (o ReadAssertionsResponse) MarshalJSON() ([]byte, error) {
 	if o.Assertions != nil {
 		toSerialize["assertions"] = o.Assertions
 	}
-	return json.Marshal(toSerialize)
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(toSerialize)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 type NullableReadAssertionsResponse struct {

--- a/model_read_authorization_model_response.go
+++ b/model_read_authorization_model_response.go
@@ -13,6 +13,8 @@
 package openfga
 
 import (
+	"bytes"
+
 	"encoding/json"
 )
 
@@ -75,7 +77,14 @@ func (o ReadAuthorizationModelResponse) MarshalJSON() ([]byte, error) {
 	if o.AuthorizationModel != nil {
 		toSerialize["authorization_model"] = o.AuthorizationModel
 	}
-	return json.Marshal(toSerialize)
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(toSerialize)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 type NullableReadAuthorizationModelResponse struct {

--- a/model_read_authorization_models_response.go
+++ b/model_read_authorization_models_response.go
@@ -13,6 +13,8 @@
 package openfga
 
 import (
+	"bytes"
+
 	"encoding/json"
 )
 
@@ -103,7 +105,14 @@ func (o ReadAuthorizationModelsResponse) MarshalJSON() ([]byte, error) {
 	if o.ContinuationToken != nil {
 		toSerialize["continuation_token"] = o.ContinuationToken
 	}
-	return json.Marshal(toSerialize)
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(toSerialize)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 type NullableReadAuthorizationModelsResponse struct {

--- a/model_read_changes_response.go
+++ b/model_read_changes_response.go
@@ -13,6 +13,8 @@
 package openfga
 
 import (
+	"bytes"
+
 	"encoding/json"
 )
 
@@ -103,7 +105,14 @@ func (o ReadChangesResponse) MarshalJSON() ([]byte, error) {
 	if o.ContinuationToken != nil {
 		toSerialize["continuation_token"] = o.ContinuationToken
 	}
-	return json.Marshal(toSerialize)
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(toSerialize)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 type NullableReadChangesResponse struct {

--- a/model_read_request.go
+++ b/model_read_request.go
@@ -13,6 +13,8 @@
 package openfga
 
 import (
+	"bytes"
+
 	"encoding/json"
 )
 
@@ -147,7 +149,14 @@ func (o ReadRequest) MarshalJSON() ([]byte, error) {
 	if o.ContinuationToken != nil {
 		toSerialize["continuation_token"] = o.ContinuationToken
 	}
-	return json.Marshal(toSerialize)
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(toSerialize)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 type NullableReadRequest struct {

--- a/model_read_request_tuple_key.go
+++ b/model_read_request_tuple_key.go
@@ -13,6 +13,8 @@
 package openfga
 
 import (
+	"bytes"
+
 	"encoding/json"
 )
 
@@ -147,7 +149,14 @@ func (o ReadRequestTupleKey) MarshalJSON() ([]byte, error) {
 	if o.Object != nil {
 		toSerialize["object"] = o.Object
 	}
-	return json.Marshal(toSerialize)
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(toSerialize)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 type NullableReadRequestTupleKey struct {

--- a/model_read_response.go
+++ b/model_read_response.go
@@ -13,6 +13,8 @@
 package openfga
 
 import (
+	"bytes"
+
 	"encoding/json"
 )
 
@@ -94,7 +96,14 @@ func (o ReadResponse) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["tuples"] = o.Tuples
 	toSerialize["continuation_token"] = o.ContinuationToken
-	return json.Marshal(toSerialize)
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(toSerialize)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 type NullableReadResponse struct {

--- a/model_relation_metadata.go
+++ b/model_relation_metadata.go
@@ -13,6 +13,8 @@
 package openfga
 
 import (
+	"bytes"
+
 	"encoding/json"
 )
 
@@ -75,7 +77,14 @@ func (o RelationMetadata) MarshalJSON() ([]byte, error) {
 	if o.DirectlyRelatedUserTypes != nil {
 		toSerialize["directly_related_user_types"] = o.DirectlyRelatedUserTypes
 	}
-	return json.Marshal(toSerialize)
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(toSerialize)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 type NullableRelationMetadata struct {

--- a/model_relation_reference.go
+++ b/model_relation_reference.go
@@ -13,6 +13,8 @@
 package openfga
 
 import (
+	"bytes"
+
 	"encoding/json"
 )
 
@@ -175,7 +177,14 @@ func (o RelationReference) MarshalJSON() ([]byte, error) {
 	if o.Condition != nil {
 		toSerialize["condition"] = o.Condition
 	}
-	return json.Marshal(toSerialize)
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(toSerialize)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 type NullableRelationReference struct {

--- a/model_relationship_condition.go
+++ b/model_relationship_condition.go
@@ -13,6 +13,8 @@
 package openfga
 
 import (
+	"bytes"
+
 	"encoding/json"
 )
 
@@ -104,7 +106,14 @@ func (o RelationshipCondition) MarshalJSON() ([]byte, error) {
 	if o.Context != nil {
 		toSerialize["context"] = o.Context
 	}
-	return json.Marshal(toSerialize)
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(toSerialize)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 type NullableRelationshipCondition struct {

--- a/model_status.go
+++ b/model_status.go
@@ -13,6 +13,8 @@
 package openfga
 
 import (
+	"bytes"
+
 	"encoding/json"
 )
 
@@ -147,7 +149,14 @@ func (o Status) MarshalJSON() ([]byte, error) {
 	if o.Details != nil {
 		toSerialize["details"] = o.Details
 	}
-	return json.Marshal(toSerialize)
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(toSerialize)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 type NullableStatus struct {

--- a/model_store.go
+++ b/model_store.go
@@ -13,6 +13,8 @@
 package openfga
 
 import (
+	"bytes"
+
 	"encoding/json"
 	"time"
 )
@@ -184,7 +186,14 @@ func (o Store) MarshalJSON() ([]byte, error) {
 	if o.DeletedAt != nil {
 		toSerialize["deleted_at"] = o.DeletedAt
 	}
-	return json.Marshal(toSerialize)
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(toSerialize)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 type NullableStore struct {

--- a/model_tuple.go
+++ b/model_tuple.go
@@ -13,6 +13,8 @@
 package openfga
 
 import (
+	"bytes"
+
 	"encoding/json"
 	"time"
 )
@@ -94,7 +96,14 @@ func (o Tuple) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["key"] = o.Key
 	toSerialize["timestamp"] = o.Timestamp
-	return json.Marshal(toSerialize)
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(toSerialize)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 type NullableTuple struct {

--- a/model_tuple_change.go
+++ b/model_tuple_change.go
@@ -13,6 +13,8 @@
 package openfga
 
 import (
+	"bytes"
+
 	"encoding/json"
 	"time"
 )
@@ -123,7 +125,14 @@ func (o TupleChange) MarshalJSON() ([]byte, error) {
 	toSerialize["tuple_key"] = o.TupleKey
 	toSerialize["operation"] = o.Operation
 	toSerialize["timestamp"] = o.Timestamp
-	return json.Marshal(toSerialize)
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(toSerialize)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 type NullableTupleChange struct {

--- a/model_tuple_key.go
+++ b/model_tuple_key.go
@@ -13,6 +13,8 @@
 package openfga
 
 import (
+	"bytes"
+
 	"encoding/json"
 )
 
@@ -156,7 +158,14 @@ func (o TupleKey) MarshalJSON() ([]byte, error) {
 	if o.Condition != nil {
 		toSerialize["condition"] = o.Condition
 	}
-	return json.Marshal(toSerialize)
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(toSerialize)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 type NullableTupleKey struct {

--- a/model_tuple_key_without_condition.go
+++ b/model_tuple_key_without_condition.go
@@ -13,6 +13,8 @@
 package openfga
 
 import (
+	"bytes"
+
 	"encoding/json"
 )
 
@@ -120,7 +122,14 @@ func (o TupleKeyWithoutCondition) MarshalJSON() ([]byte, error) {
 	toSerialize["user"] = o.User
 	toSerialize["relation"] = o.Relation
 	toSerialize["object"] = o.Object
-	return json.Marshal(toSerialize)
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(toSerialize)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 type NullableTupleKeyWithoutCondition struct {

--- a/model_tuple_to_userset.go
+++ b/model_tuple_to_userset.go
@@ -13,6 +13,8 @@
 package openfga
 
 import (
+	"bytes"
+
 	"encoding/json"
 )
 
@@ -93,7 +95,14 @@ func (o TupleToUserset) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["tupleset"] = o.Tupleset
 	toSerialize["computedUserset"] = o.ComputedUserset
-	return json.Marshal(toSerialize)
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(toSerialize)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 type NullableTupleToUserset struct {

--- a/model_type_definition.go
+++ b/model_type_definition.go
@@ -13,6 +13,8 @@
 package openfga
 
 import (
+	"bytes"
+
 	"encoding/json"
 )
 
@@ -138,7 +140,14 @@ func (o TypeDefinition) MarshalJSON() ([]byte, error) {
 	if o.Metadata != nil {
 		toSerialize["metadata"] = o.Metadata
 	}
-	return json.Marshal(toSerialize)
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(toSerialize)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 type NullableTypeDefinition struct {

--- a/model_users.go
+++ b/model_users.go
@@ -13,6 +13,8 @@
 package openfga
 
 import (
+	"bytes"
+
 	"encoding/json"
 )
 
@@ -66,7 +68,14 @@ func (o *Users) SetUsers(v []string) {
 func (o Users) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["users"] = o.Users
-	return json.Marshal(toSerialize)
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(toSerialize)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 type NullableUsers struct {

--- a/model_userset.go
+++ b/model_userset.go
@@ -13,6 +13,8 @@
 package openfga
 
 import (
+	"bytes"
+
 	"encoding/json"
 )
 
@@ -256,7 +258,14 @@ func (o Userset) MarshalJSON() ([]byte, error) {
 	if o.Difference != nil {
 		toSerialize["difference"] = o.Difference
 	}
-	return json.Marshal(toSerialize)
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(toSerialize)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 type NullableUserset struct {

--- a/model_userset_tree.go
+++ b/model_userset_tree.go
@@ -13,6 +13,8 @@
 package openfga
 
 import (
+	"bytes"
+
 	"encoding/json"
 )
 
@@ -75,7 +77,14 @@ func (o UsersetTree) MarshalJSON() ([]byte, error) {
 	if o.Root != nil {
 		toSerialize["root"] = o.Root
 	}
-	return json.Marshal(toSerialize)
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(toSerialize)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 type NullableUsersetTree struct {

--- a/model_userset_tree_difference.go
+++ b/model_userset_tree_difference.go
@@ -13,6 +13,8 @@
 package openfga
 
 import (
+	"bytes"
+
 	"encoding/json"
 )
 
@@ -93,7 +95,14 @@ func (o UsersetTreeDifference) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["base"] = o.Base
 	toSerialize["subtract"] = o.Subtract
-	return json.Marshal(toSerialize)
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(toSerialize)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 type NullableUsersetTreeDifference struct {

--- a/model_userset_tree_tuple_to_userset.go
+++ b/model_userset_tree_tuple_to_userset.go
@@ -13,6 +13,8 @@
 package openfga
 
 import (
+	"bytes"
+
 	"encoding/json"
 )
 
@@ -93,7 +95,14 @@ func (o UsersetTreeTupleToUserset) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["tupleset"] = o.Tupleset
 	toSerialize["computed"] = o.Computed
-	return json.Marshal(toSerialize)
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(toSerialize)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 type NullableUsersetTreeTupleToUserset struct {

--- a/model_usersets.go
+++ b/model_usersets.go
@@ -13,6 +13,8 @@
 package openfga
 
 import (
+	"bytes"
+
 	"encoding/json"
 )
 
@@ -66,7 +68,14 @@ func (o *Usersets) SetChild(v []Userset) {
 func (o Usersets) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["child"] = o.Child
-	return json.Marshal(toSerialize)
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(toSerialize)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 type NullableUsersets struct {

--- a/model_validation_error_message_response.go
+++ b/model_validation_error_message_response.go
@@ -13,6 +13,8 @@
 package openfga
 
 import (
+	"bytes"
+
 	"encoding/json"
 )
 
@@ -115,7 +117,14 @@ func (o ValidationErrorMessageResponse) MarshalJSON() ([]byte, error) {
 	if o.Message != nil {
 		toSerialize["message"] = o.Message
 	}
-	return json.Marshal(toSerialize)
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(toSerialize)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 type NullableValidationErrorMessageResponse struct {

--- a/model_write_assertions_request.go
+++ b/model_write_assertions_request.go
@@ -13,6 +13,8 @@
 package openfga
 
 import (
+	"bytes"
+
 	"encoding/json"
 )
 
@@ -66,7 +68,14 @@ func (o *WriteAssertionsRequest) SetAssertions(v []Assertion) {
 func (o WriteAssertionsRequest) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["assertions"] = o.Assertions
-	return json.Marshal(toSerialize)
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(toSerialize)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 type NullableWriteAssertionsRequest struct {

--- a/model_write_authorization_model_request.go
+++ b/model_write_authorization_model_request.go
@@ -13,6 +13,8 @@
 package openfga
 
 import (
+	"bytes"
+
 	"encoding/json"
 )
 
@@ -129,7 +131,14 @@ func (o WriteAuthorizationModelRequest) MarshalJSON() ([]byte, error) {
 	if o.Conditions != nil {
 		toSerialize["conditions"] = o.Conditions
 	}
-	return json.Marshal(toSerialize)
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(toSerialize)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 type NullableWriteAuthorizationModelRequest struct {

--- a/model_write_authorization_model_response.go
+++ b/model_write_authorization_model_response.go
@@ -13,6 +13,8 @@
 package openfga
 
 import (
+	"bytes"
+
 	"encoding/json"
 )
 
@@ -66,7 +68,14 @@ func (o *WriteAuthorizationModelResponse) SetAuthorizationModelId(v string) {
 func (o WriteAuthorizationModelResponse) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["authorization_model_id"] = o.AuthorizationModelId
-	return json.Marshal(toSerialize)
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(toSerialize)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 type NullableWriteAuthorizationModelResponse struct {

--- a/model_write_request.go
+++ b/model_write_request.go
@@ -13,6 +13,8 @@
 package openfga
 
 import (
+	"bytes"
+
 	"encoding/json"
 )
 
@@ -147,7 +149,14 @@ func (o WriteRequest) MarshalJSON() ([]byte, error) {
 	if o.AuthorizationModelId != nil {
 		toSerialize["authorization_model_id"] = o.AuthorizationModelId
 	}
-	return json.Marshal(toSerialize)
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(toSerialize)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 type NullableWriteRequest struct {

--- a/model_write_request_deletes.go
+++ b/model_write_request_deletes.go
@@ -13,6 +13,8 @@
 package openfga
 
 import (
+	"bytes"
+
 	"encoding/json"
 )
 
@@ -66,7 +68,14 @@ func (o *WriteRequestDeletes) SetTupleKeys(v []TupleKeyWithoutCondition) {
 func (o WriteRequestDeletes) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["tuple_keys"] = o.TupleKeys
-	return json.Marshal(toSerialize)
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(toSerialize)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 type NullableWriteRequestDeletes struct {

--- a/model_write_request_writes.go
+++ b/model_write_request_writes.go
@@ -13,6 +13,8 @@
 package openfga
 
 import (
+	"bytes"
+
 	"encoding/json"
 )
 
@@ -66,7 +68,14 @@ func (o *WriteRequestWrites) SetTupleKeys(v []TupleKey) {
 func (o WriteRequestWrites) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["tuple_keys"] = o.TupleKeys
-	return json.Marshal(toSerialize)
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(toSerialize)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 type NullableWriteRequestWrites struct {


### PR DESCRIPTION
## Description

The behaviour of json.Marshal is to escape any HTML characters in a string, by using json.Encoder we are able to disable the escaping of these characters

## References

Generated from https://github.com/openfga/sdk-generator/pull/280
Will allow us to close https://github.com/openfga/cli/issues/188

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
