### PR TITLE
 chore: add test to cover not sending empty array when other has data

### DIFF
--- a/api_open_fga.go
+++ b/api_open_fga.go
@@ -221,7 +221,9 @@ type OpenFgaApi interface {
 
 	/*
 		 * Read Get tuples from the store that matches a query, without following userset rewrite rules
-		 * The Read API will return the tuples for a certain store that match a query filter specified in the body of the request. It is different from the `/stores/{store_id}/expand` API in that it only returns relationship tuples that are stored in the system and satisfy the query.
+		 * The Read API will return the tuples for a certain store that match a query filter specified in the body of the request.
+	The API doesn't guarantee order by any field.
+	It is different from the `/stores/{store_id}/expand` API in that it only returns relationship tuples that are stored in the system and satisfy the query.
 	In the body:
 	1. `tuple_key` is optional. If not specified, it will return all tuples in the store.
 	2. `tuple_key.object` is mandatory if `tuple_key` is specified. It can be a full object (e.g., `type:object_id`) or type only (e.g., `type:`).
@@ -2544,8 +2546,10 @@ func (r ApiReadRequest) Execute() (ReadResponse, *_nethttp.Response, error) {
 
 /*
   - Read Get tuples from the store that matches a query, without following userset rewrite rules
-  - The Read API will return the tuples for a certain store that match a query filter specified in the body of the request. It is different from the `/stores/{store_id}/expand` API in that it only returns relationship tuples that are stored in the system and satisfy the query.
+  - The Read API will return the tuples for a certain store that match a query filter specified in the body of the request.
 
+The API doesn't guarantee order by any field.
+It is different from the `/stores/{store_id}/expand` API in that it only returns relationship tuples that are stored in the system and satisfy the query.
 In the body:
 1. `tuple_key` is optional. If not specified, it will return all tuples in the store.
 2. `tuple_key.object` is mandatory if `tuple_key` is specified. It can be a full object (e.g., `type:object_id`) or type only (e.g., `type:`).

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -972,6 +972,7 @@ func TestOpenFgaClient(t *testing.T) {
 				Relation: "viewer",
 				Object:   "document:roadmap",
 			}},
+			Deletes: []ClientTupleKeyWithoutCondition{},
 		}
 		options := ClientWriteOptions{
 			AuthorizationModelId: openfga.PtrString("01GAHCE4YVKPQEKZQHT2R89MQV"),

--- a/example/Makefile
+++ b/example/Makefile
@@ -11,4 +11,4 @@ run: restore
 
 run-openfga:
 	docker pull docker.io/openfga/openfga:${openfga_version} && \
-		docker run -p 8080:8080 docker.io/openfga/openfga:${openfga_version}
+		docker run -p 8080:8080 docker.io/openfga/openfga:${openfga_version} run


### PR DESCRIPTION
## Description

Adds the Deletes property to the test to ensure that we don't pass this when it is empty. Given that we don't match on body this isn't really much gain but it will help to ensure we maintain this in future if we improve testing.

Also copies across some recent changes from the sdk-generator repo/api docs

## References

Part of https://github.com/openfga/sdk-generator/issues/299
Generated from https://github.com/openfga/sdk-generator/pull/306

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
