### PR TITLE
chore: bump to go 1.21

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -12,7 +12,7 @@ A bare bones example. It creates a store, and runs a set of calls against it inc
 Prerequisites:
 - `docker`
 - `make`
-- `go` 1.20+
+- `go` 1.21+
 
 #### Run using a published SDK
 

--- a/example/example1/go.mod
+++ b/example/example1/go.mod
@@ -1,6 +1,6 @@
 module example1
 
-go 1.20
+go 1.21
 
 require github.com/openfga/go-sdk v0.3.5
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openfga/go-sdk
 
-go 1.20
+go 1.21
 
 require (
 	github.com/jarcoal/httpmock v1.3.1


### PR DESCRIPTION
## Description

Bumps the go requirement to v1.21 in line with the support policy of the last 2 major version (1.21 and 1.22).

## References

Generated from https://github.com/openfga/sdk-generator/pull/311

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
