### PR TITLE
fix: The README example in Go-SDK uses inconsistent name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,7 +505,7 @@ options := ClientWriteOptions{
     // You can rely on the model id set in the configuration or override it for this specific request
     AuthorizationModelId: openfga.PtrString("01GAHCE4YVKPQEKZQHT2R89MQV"),
 }
-data, err := fgaClient.Write(context.Background()).Body(requestBody).Options(options).Execute()
+data, err := fgaClient.Write(context.Background()).Body(body).Options(options).Execute()
 ```
 
 Convenience `WriteTuples` and `DeleteTuples` methods are also available.
@@ -541,7 +541,7 @@ options := ClientWriteOptions{
         MaxPerChunk: 1, // Maximum number of requests to be sent in a transaction in a particular chunk
     },
 }
-data, err := fgaClient.Write(context.Background()).Body(requestBody).Options(options).Execute()
+data, err := fgaClient.Write(context.Background()).Body(body).Options(options).Execute()
 
 // data.Writes = [{
 //   TupleKey: { User, Relation, Object },


### PR DESCRIPTION

## References
closes https://github.com/openfga/go-sdk/issues/48

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
