### PR TITLE
feat!: remove store ID from API config, allow override per-request

### DIFF
--- a/.openapi-generator/FILES
+++ b/.openapi-generator/FILES
@@ -83,6 +83,7 @@ docs/TupleToUserset.md
 docs/TypeDefinition.md
 docs/TypeName.md
 docs/TypedWildcard.md
+docs/UnauthenticatedResponse.md
 docs/UnprocessableContentErrorCode.md
 docs/UnprocessableContentMessageResponse.md
 docs/User.md
@@ -171,6 +172,7 @@ model_tuple_to_userset.go
 model_type_definition.go
 model_type_name.go
 model_typed_wildcard.go
+model_unauthenticated_response.go
 model_unprocessable_content_error_code.go
 model_unprocessable_content_message_response.go
 model_user.go

--- a/README.md
+++ b/README.md
@@ -775,6 +775,8 @@ List the users who have a certain relation to a particular type.
 options := ClientListRelationsOptions{
     // You can rely on the model id set in the configuration or override it for this specific request
     AuthorizationModelId: openfga.PtrString("01GAHCE4YVKPQEKZQHT2R89MQV"),
+    // Max number of requests to issue in parallel, defaults to 10
+    MaxParallelRequests: openfga.PtrInt32(5),
 }
 
 // Only a single filter is allowed by the API for the time being

--- a/README.md
+++ b/README.md
@@ -744,6 +744,8 @@ List the relations a user has on an object.
 options := ClientListRelationsOptions{
     // You can rely on the model id set in the configuration or override it for this specific request
     AuthorizationModelId: openfga.PtrString("01GAHCE4YVKPQEKZQHT2R89MQV"),
+    // Max number of requests to issue in parallel, defaults to 10
+    MaxParallelRequests: openfga.PtrInt32(5),
 }
 body := ClientListRelationsRequest{
     User:      "user:81684243-9356-4421-8fbf-a4f8d36aa31b",

--- a/README.md
+++ b/README.md
@@ -773,8 +773,6 @@ List the users who have a certain relation to a particular type.
 options := ClientListRelationsOptions{
     // You can rely on the model id set in the configuration or override it for this specific request
     AuthorizationModelId: openfga.PtrString("01GAHCE4YVKPQEKZQHT2R89MQV"),
-    // Max number of requests to issue in parallel, defaults to 10
-    MaxParallelRequests: openfga.PtrInt32(5),
 }
 
 // Only a single filter is allowed by the API for the time being
@@ -896,7 +894,7 @@ Class | Method | HTTP request | Description
 *OpenFgaApi* | [**GetStore**](docs/OpenFgaApi.md#getstore) | **Get** /stores/{store_id} | Get a store
 *OpenFgaApi* | [**ListObjects**](docs/OpenFgaApi.md#listobjects) | **Post** /stores/{store_id}/list-objects | List all objects of the given type that the user has a relation with
 *OpenFgaApi* | [**ListStores**](docs/OpenFgaApi.md#liststores) | **Get** /stores | List all stores
-*OpenFgaApi* | [**ListUsers**](docs/OpenFgaApi.md#listusers) | **Post** /stores/{store_id}/list-users | List all users of the given type that the object has a relation with
+*OpenFgaApi* | [**ListUsers**](docs/OpenFgaApi.md#listusers) | **Post** /stores/{store_id}/list-users | [EXPERIMENTAL] List the users matching the provided filter who have a certain relation to a particular type.
 *OpenFgaApi* | [**Read**](docs/OpenFgaApi.md#read) | **Post** /stores/{store_id}/read | Get tuples from the store that matches a query, without following userset rewrite rules
 *OpenFgaApi* | [**ReadAssertions**](docs/OpenFgaApi.md#readassertions) | **Get** /stores/{store_id}/assertions/{authorization_model_id} | Read assertions for an authorization model ID
 *OpenFgaApi* | [**ReadAuthorizationModel**](docs/OpenFgaApi.md#readauthorizationmodel) | **Get** /stores/{store_id}/authorization-models/{id} | Return a particular version of an authorization model
@@ -969,6 +967,7 @@ Class | Method | HTTP request | Description
  - [TypeDefinition](docs/TypeDefinition.md)
  - [TypeName](docs/TypeName.md)
  - [TypedWildcard](docs/TypedWildcard.md)
+ - [UnauthenticatedResponse](docs/UnauthenticatedResponse.md)
  - [UnprocessableContentErrorCode](docs/UnprocessableContentErrorCode.md)
  - [UnprocessableContentMessageResponse](docs/UnprocessableContentMessageResponse.md)
  - [User](docs/User.md)

--- a/api_client.go
+++ b/api_client.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community
@@ -44,7 +44,7 @@ type ErrorResponse struct {
 	Message string `json:"message"`
 }
 
-// APIClient manages communication with the OpenFGA API v0.1
+// APIClient manages communication with the OpenFGA API v1.x
 // In most cases there should be only one, shared, APIClient.
 type APIClient struct {
 	cfg    *Configuration
@@ -88,14 +88,6 @@ func NewAPIClient(cfg *Configuration) *APIClient {
 	c.OpenFgaApi = (*OpenFgaApiService)(&c.common)
 
 	return c
-}
-
-func (a APIClient) GetStoreId() string {
-	return a.cfg.StoreId
-}
-
-func (a APIClient) SetStoreId(storeId string) {
-	a.cfg.StoreId = storeId
 }
 
 // selectHeaderContentType select a content type from the available list.

--- a/api_open_fga_test.go
+++ b/api_open_fga_test.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community
@@ -42,18 +42,6 @@ func TestOpenFgaApiConfiguration(t *testing.T) {
 		}
 	})
 
-	t.Run("Providing no store id when calling endpoints that require it should error", func(t *testing.T) {
-		configuration, err := NewConfiguration(Configuration{
-			ApiHost: "api.fga.example",
-		})
-
-		apiClient := NewAPIClient(configuration)
-
-		if _, _, err = apiClient.OpenFgaApi.ReadAuthorizationModels(context.Background()).Execute(); err == nil {
-			t.Fatalf("Expected an error when storeId is required but not provided")
-		}
-	})
-
 	t.Run("Providing no ApiHost should error", func(t *testing.T) {
 		_, err := NewConfiguration(Configuration{})
 
@@ -69,17 +57,6 @@ func TestOpenFgaApiConfiguration(t *testing.T) {
 
 		if err == nil {
 			t.Fatalf("Expected an error when ApiHost is invalid (scheme is part of the host)")
-		}
-	})
-
-	t.Run("Providing invalid storeid should result in error", func(t *testing.T) {
-		_, err := NewConfiguration(Configuration{
-			ApiHost: "api.fga.example",
-			StoreId: "invalid",
-		})
-
-		if err == nil {
-			t.Fatalf("Expect error when invalid storeid is provided")
 		}
 	})
 
@@ -99,7 +76,6 @@ func TestOpenFgaApiConfiguration(t *testing.T) {
 	t.Run("should issue a successful network call when using ApiToken credential method", func(t *testing.T) {
 		configuration, err := NewConfiguration(Configuration{
 			ApiHost: "api.fga.example",
-			StoreId: "01GXSB9YR785C4FYS3C0RTG7B2",
 			Credentials: &credentials.Credentials{
 				Method: credentials.CredentialsMethodApiToken,
 				Config: &credentials.Config{
@@ -115,7 +91,7 @@ func TestOpenFgaApiConfiguration(t *testing.T) {
 
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
-		httpmock.RegisterResponder("GET", fmt.Sprintf("%s/stores/%s/authorization-models", configuration.ApiUrl, configuration.StoreId),
+		httpmock.RegisterResponder("GET", fmt.Sprintf("%s/stores/%s/authorization-models", configuration.ApiUrl, "01GXSB9YR785C4FYS3C0RTG7B2"),
 			func(req *http.Request) (*http.Response, error) {
 				resp, err := httpmock.NewJsonResponse(200, ReadAuthorizationModelsResponse{AuthorizationModels: []AuthorizationModel{
 					{
@@ -134,7 +110,7 @@ func TestOpenFgaApiConfiguration(t *testing.T) {
 			},
 		)
 
-		if _, _, err = apiClient.OpenFgaApi.ReadAuthorizationModels(context.Background()).Execute(); err != nil {
+		if _, _, err = apiClient.OpenFgaApi.ReadAuthorizationModels(context.Background(), "01GXSB9YR785C4FYS3C0RTG7B2").Execute(); err != nil {
 			t.Fatalf("%v", err)
 		}
 	})
@@ -142,7 +118,6 @@ func TestOpenFgaApiConfiguration(t *testing.T) {
 	t.Run("In ClientCredentials method, providing no client id, secret or issuer should error", func(t *testing.T) {
 		_, err := NewConfiguration(Configuration{
 			ApiHost: "https://api.fga.example",
-			StoreId: "01GXSB9YR785C4FYS3C0RTG7B2",
 			Credentials: &credentials.Credentials{
 				Method: credentials.CredentialsMethodApiToken,
 				Config: &credentials.Config{
@@ -157,7 +132,6 @@ func TestOpenFgaApiConfiguration(t *testing.T) {
 
 		_, err = NewConfiguration(Configuration{
 			ApiHost: "https://api.fga.example",
-			StoreId: "01GXSB9YR785C4FYS3C0RTG7B2",
 			Credentials: &credentials.Credentials{
 				Method: credentials.CredentialsMethodApiToken,
 				Config: &credentials.Config{
@@ -174,7 +148,6 @@ func TestOpenFgaApiConfiguration(t *testing.T) {
 
 		_, err = NewConfiguration(Configuration{
 			ApiHost: "https://api.fga.example",
-			StoreId: "01GXSB9YR785C4FYS3C0RTG7B2",
 			Credentials: &credentials.Credentials{
 				Method: credentials.CredentialsMethodApiToken,
 				Config: &credentials.Config{
@@ -191,7 +164,6 @@ func TestOpenFgaApiConfiguration(t *testing.T) {
 
 		_, err = NewConfiguration(Configuration{
 			ApiHost: "api.fga.example",
-			StoreId: "01GXSB9YR785C4FYS3C0RTG7B2",
 			Credentials: &credentials.Credentials{
 				Method: credentials.CredentialsMethodClientCredentials,
 				Config: &credentials.Config{
@@ -256,7 +228,7 @@ func TestOpenFgaApiConfiguration(t *testing.T) {
 
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
-		httpmock.RegisterResponder("GET", fmt.Sprintf("%s/stores/%s/authorization-models", configuration.ApiUrl, configuration.StoreId),
+		httpmock.RegisterResponder("GET", fmt.Sprintf("%s/stores/%s/authorization-models", configuration.ApiUrl, "01GXSB9YR785C4FYS3C0RTG7B2"),
 			func(req *http.Request) (*http.Response, error) {
 				resp, err := httpmock.NewJsonResponse(200, ReadAuthorizationModelsResponse{AuthorizationModels: []AuthorizationModel{
 					{
@@ -287,7 +259,7 @@ func TestOpenFgaApiConfiguration(t *testing.T) {
 			},
 		)
 
-		if _, _, err = apiClient.OpenFgaApi.ReadAuthorizationModels(context.Background()).Execute(); err != nil {
+		if _, _, err = apiClient.OpenFgaApi.ReadAuthorizationModels(context.Background(), "01GXSB9YR785C4FYS3C0RTG7B2").Execute(); err != nil {
 			t.Fatalf("%v", err)
 		}
 
@@ -296,7 +268,7 @@ func TestOpenFgaApiConfiguration(t *testing.T) {
 		if numCalls != 1 {
 			t.Fatalf("Expected call to get access token to be made exactly once, saw: %d", numCalls)
 		}
-		numCalls = info[fmt.Sprintf("GET %s/stores/%s/authorization-models", configuration.ApiUrl, configuration.StoreId)]
+		numCalls = info[fmt.Sprintf("GET %s/stores/%s/authorization-models", configuration.ApiUrl, "01GXSB9YR785C4FYS3C0RTG7B2")]
 		if numCalls != 1 {
 			t.Fatalf("Expected call to get authorization models to be made exactly once, saw: %d", numCalls)
 		}
@@ -317,8 +289,7 @@ func TestOpenFgaApiConfiguration(t *testing.T) {
 		t.Run("should issue a network call to get the token at the first request if client id is provided", func(t *testing.T) {
 			t.Run("with Auth0 configuration", func(t *testing.T) {
 				clientCredentialsFirstRequestTest(t, Configuration{
-					ApiUrl:  "http://api.fga.example",
-					StoreId: "01GXSB9YR785C4FYS3C0RTG7B2",
+					ApiUrl: "http://api.fga.example",
 					Credentials: &credentials.Credentials{
 						Method: credentials.CredentialsMethodClientCredentials,
 						Config: &credentials.Config{
@@ -332,8 +303,7 @@ func TestOpenFgaApiConfiguration(t *testing.T) {
 			})
 			t.Run("with OAuth2 configuration", func(t *testing.T) {
 				clientCredentialsFirstRequestTest(t, Configuration{
-					ApiUrl:  "http://api.fga.example",
-					StoreId: "01GXSB9YR785C4FYS3C0RTG7B2",
+					ApiUrl: "http://api.fga.example",
 					Credentials: &credentials.Credentials{
 						Method: credentials.CredentialsMethodClientCredentials,
 						Config: &credentials.Config{
@@ -350,7 +320,6 @@ func TestOpenFgaApiConfiguration(t *testing.T) {
 	t.Run("should not issue a network call to get the token at the first request if the clientId is not provided", func(t *testing.T) {
 		configuration, err := NewConfiguration(Configuration{
 			ApiHost: "api.fga.example",
-			StoreId: "01GXSB9YR785C4FYS3C0RTG7B2",
 			Credentials: &credentials.Credentials{
 				Method: credentials.CredentialsMethodNone,
 				Config: &credentials.Config{ClientCredentialsApiTokenIssuer: "tokenissuer.api.example"},
@@ -365,7 +334,7 @@ func TestOpenFgaApiConfiguration(t *testing.T) {
 
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
-		httpmock.RegisterResponder("GET", fmt.Sprintf("%s/stores/%s/authorization-models", configuration.ApiUrl, configuration.StoreId),
+		httpmock.RegisterResponder("GET", fmt.Sprintf("%s/stores/%s/authorization-models", configuration.ApiUrl, "01GXSB9YR785C4FYS3C0RTG7B2"),
 			func(req *http.Request) (*http.Response, error) {
 				resp, err := httpmock.NewJsonResponse(200, ReadAuthorizationModelsResponse{AuthorizationModels: []AuthorizationModel{
 					{
@@ -383,7 +352,7 @@ func TestOpenFgaApiConfiguration(t *testing.T) {
 				return resp, nil
 			},
 		)
-		if _, _, err = apiClient.OpenFgaApi.ReadAuthorizationModels(context.Background()).Execute(); err != nil {
+		if _, _, err = apiClient.OpenFgaApi.ReadAuthorizationModels(context.Background(), "01GXSB9YR785C4FYS3C0RTG7B2").Execute(); err != nil {
 			t.Fatalf("%v", err)
 		}
 
@@ -392,65 +361,9 @@ func TestOpenFgaApiConfiguration(t *testing.T) {
 		if numCalls != 0 {
 			t.Fatalf("Unexpected call to get access token made. Expected 0, saw: %d", numCalls)
 		}
-		numCalls = info[fmt.Sprintf("GET %s/stores/%s/authorization-models", configuration.ApiUrl, configuration.StoreId)]
+		numCalls = info[fmt.Sprintf("GET %s/stores/%s/authorization-models", configuration.ApiUrl, "01GXSB9YR785C4FYS3C0RTG7B2")]
 		if numCalls != 1 {
 			t.Fatalf("Expected call to get authorization models to be made exactly once, saw: %d", numCalls)
-		}
-	})
-
-	t.Run("Updating StoreId after initialization should work", func(t *testing.T) {
-		configuration, err := NewConfiguration(Configuration{
-			ApiHost: "api.fga.example",
-			Credentials: &credentials.Credentials{
-				Method: credentials.CredentialsMethodClientCredentials,
-				Config: &credentials.Config{
-					ClientCredentialsClientId:       "some-id",
-					ClientCredentialsClientSecret:   "some-secret",
-					ClientCredentialsApiAudience:    "some-audience",
-					ClientCredentialsApiTokenIssuer: "tokenissuer.fga.example",
-				},
-			},
-		})
-
-		if err != nil {
-			t.Fatalf("%v", err)
-		}
-
-		apiClient := NewAPIClient(configuration)
-		if apiClient.GetStoreId() != "" {
-			t.Fatalf("apiClient.GetStoreId() = \"\", want %v", apiClient.GetStoreId())
-		}
-
-		storeId := "some-id"
-		apiClient.SetStoreId(storeId)
-		if apiClient.GetStoreId() != storeId {
-			t.Fatalf("apiClient.GetStoreId() = %v, want %v", apiClient.GetStoreId(), storeId)
-		}
-
-		storeId = "some-other-id"
-		apiClient.SetStoreId(storeId)
-		if apiClient.GetStoreId() != storeId {
-			t.Fatalf("apiClient.GetStoreId() = %v, want %v", apiClient.GetStoreId(), storeId)
-		}
-	})
-
-	t.Run("Issuing a call to a method that requires StoreId without providing it should error", func(t *testing.T) {
-		configuration, err := NewConfiguration(Configuration{
-			ApiHost: "api.fga.example",
-		})
-
-		if err != nil {
-			t.Fatalf("%v", err)
-		}
-
-		apiClient := NewAPIClient(configuration)
-		if apiClient.GetStoreId() != "" {
-			t.Fatalf("apiClient.GetStoreId() = \"\", want %v", apiClient.GetStoreId())
-		}
-
-		_, _, err = apiClient.OpenFgaApi.ReadAuthorizationModels(context.Background()).Execute()
-		if err == nil {
-			t.Fatalf("Expected an error, got none")
 		}
 	})
 }
@@ -458,7 +371,6 @@ func TestOpenFgaApiConfiguration(t *testing.T) {
 func TestOpenFgaApi(t *testing.T) {
 	configuration, err := NewConfiguration(Configuration{
 		ApiHost: "api.fga.example",
-		StoreId: "01GXSB9YR785C4FYS3C0RTG7B2",
 	})
 	if err != nil {
 		t.Fatalf("%v", err)
@@ -482,7 +394,7 @@ func TestOpenFgaApi(t *testing.T) {
 
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
-		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", configuration.ApiUrl, configuration.StoreId, test.RequestPath),
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", configuration.ApiUrl, "01GXSB9YR785C4FYS3C0RTG7B2", test.RequestPath),
 			func(req *http.Request) (*http.Response, error) {
 				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
 				if err != nil {
@@ -492,7 +404,7 @@ func TestOpenFgaApi(t *testing.T) {
 			},
 		)
 
-		got, response, err := apiClient.OpenFgaApi.ReadAuthorizationModels(context.Background()).Execute()
+		got, response, err := apiClient.OpenFgaApi.ReadAuthorizationModels(context.Background(), "01GXSB9YR785C4FYS3C0RTG7B2").Execute()
 		if err != nil {
 			t.Fatalf("%v", err)
 		}
@@ -545,7 +457,7 @@ func TestOpenFgaApi(t *testing.T) {
 
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
-		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", configuration.ApiUrl, configuration.StoreId, test.RequestPath),
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", configuration.ApiUrl, "01GXSB9YR785C4FYS3C0RTG7B2", test.RequestPath),
 			func(req *http.Request) (*http.Response, error) {
 				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
 				if err != nil {
@@ -554,7 +466,7 @@ func TestOpenFgaApi(t *testing.T) {
 				return resp, nil
 			},
 		)
-		got, response, err := apiClient.OpenFgaApi.WriteAuthorizationModel(context.Background()).Body(requestBody).Execute()
+		got, response, err := apiClient.OpenFgaApi.WriteAuthorizationModel(context.Background(), "01GXSB9YR785C4FYS3C0RTG7B2").Body(requestBody).Execute()
 		if err != nil {
 			t.Fatalf("%v", err)
 		}
@@ -586,7 +498,7 @@ func TestOpenFgaApi(t *testing.T) {
 
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
-		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s/%s", configuration.ApiUrl, configuration.StoreId, test.RequestPath, modelId),
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s/%s", configuration.ApiUrl, "01GXSB9YR785C4FYS3C0RTG7B2", test.RequestPath, modelId),
 			func(req *http.Request) (*http.Response, error) {
 				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
 				if err != nil {
@@ -595,7 +507,7 @@ func TestOpenFgaApi(t *testing.T) {
 				return resp, nil
 			},
 		)
-		got, response, err := apiClient.OpenFgaApi.ReadAuthorizationModel(context.Background(), modelId).Execute()
+		got, response, err := apiClient.OpenFgaApi.ReadAuthorizationModel(context.Background(), "01GXSB9YR785C4FYS3C0RTG7B2", modelId).Execute()
 		if err != nil {
 			t.Fatalf("%v", err)
 		}
@@ -638,7 +550,7 @@ func TestOpenFgaApi(t *testing.T) {
 
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
-		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", configuration.ApiUrl, configuration.StoreId, test.RequestPath),
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", configuration.ApiUrl, "01GXSB9YR785C4FYS3C0RTG7B2", test.RequestPath),
 			func(req *http.Request) (*http.Response, error) {
 				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
 				if err != nil {
@@ -647,7 +559,7 @@ func TestOpenFgaApi(t *testing.T) {
 				return resp, nil
 			},
 		)
-		got, response, err := apiClient.OpenFgaApi.Check(context.Background()).Body(requestBody).Execute()
+		got, response, err := apiClient.OpenFgaApi.Check(context.Background(), "01GXSB9YR785C4FYS3C0RTG7B2").Body(requestBody).Execute()
 		if err != nil {
 			t.Fatalf("%v", err)
 		}
@@ -692,7 +604,7 @@ func TestOpenFgaApi(t *testing.T) {
 
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
-		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", configuration.ApiUrl, configuration.StoreId, test.RequestPath),
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", configuration.ApiUrl, "01GXSB9YR785C4FYS3C0RTG7B2", test.RequestPath),
 			func(req *http.Request) (*http.Response, error) {
 				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
 				if err != nil {
@@ -701,7 +613,7 @@ func TestOpenFgaApi(t *testing.T) {
 				return resp, nil
 			},
 		)
-		_, response, err := apiClient.OpenFgaApi.Write(context.Background()).Body(requestBody).Execute()
+		_, response, err := apiClient.OpenFgaApi.Write(context.Background(), "01GXSB9YR785C4FYS3C0RTG7B2").Body(requestBody).Execute()
 		if err != nil {
 			t.Fatalf("%v", err)
 		}
@@ -738,7 +650,7 @@ func TestOpenFgaApi(t *testing.T) {
 
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
-		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", configuration.ApiUrl, configuration.StoreId, test.RequestPath),
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", configuration.ApiUrl, "01GXSB9YR785C4FYS3C0RTG7B2", test.RequestPath),
 			func(req *http.Request) (*http.Response, error) {
 				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
 				if err != nil {
@@ -747,7 +659,7 @@ func TestOpenFgaApi(t *testing.T) {
 				return resp, nil
 			},
 		)
-		_, response, err := apiClient.OpenFgaApi.Write(context.Background()).Body(requestBody).Execute()
+		_, response, err := apiClient.OpenFgaApi.Write(context.Background(), "01GXSB9YR785C4FYS3C0RTG7B2").Body(requestBody).Execute()
 		if err != nil {
 			t.Fatalf("%v", err)
 		}
@@ -781,7 +693,7 @@ func TestOpenFgaApi(t *testing.T) {
 
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
-		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", configuration.ApiUrl, configuration.StoreId, test.RequestPath),
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", configuration.ApiUrl, "01GXSB9YR785C4FYS3C0RTG7B2", test.RequestPath),
 			func(req *http.Request) (*http.Response, error) {
 				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
 				if err != nil {
@@ -790,7 +702,7 @@ func TestOpenFgaApi(t *testing.T) {
 				return resp, nil
 			},
 		)
-		got, response, err := apiClient.OpenFgaApi.Expand(context.Background()).Body(requestBody).Execute()
+		got, response, err := apiClient.OpenFgaApi.Expand(context.Background(), "01GXSB9YR785C4FYS3C0RTG7B2").Body(requestBody).Execute()
 		if err != nil {
 			t.Fatalf("%v", err)
 		}
@@ -829,7 +741,7 @@ func TestOpenFgaApi(t *testing.T) {
 
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
-		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", configuration.ApiUrl, configuration.StoreId, test.RequestPath),
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", configuration.ApiUrl, "01GXSB9YR785C4FYS3C0RTG7B2", test.RequestPath),
 			func(req *http.Request) (*http.Response, error) {
 				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
 				if err != nil {
@@ -838,7 +750,7 @@ func TestOpenFgaApi(t *testing.T) {
 				return resp, nil
 			},
 		)
-		got, response, err := apiClient.OpenFgaApi.Read(context.Background()).Body(requestBody).Execute()
+		got, response, err := apiClient.OpenFgaApi.Read(context.Background(), "01GXSB9YR785C4FYS3C0RTG7B2").Body(requestBody).Execute()
 		if err != nil {
 			t.Fatalf("%v", err)
 		}
@@ -873,7 +785,7 @@ func TestOpenFgaApi(t *testing.T) {
 
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
-		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", configuration.ApiUrl, configuration.StoreId, test.RequestPath),
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", configuration.ApiUrl, "01GXSB9YR785C4FYS3C0RTG7B2", test.RequestPath),
 			func(req *http.Request) (*http.Response, error) {
 				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
 				if err != nil {
@@ -882,7 +794,7 @@ func TestOpenFgaApi(t *testing.T) {
 				return resp, nil
 			},
 		)
-		got, response, err := apiClient.OpenFgaApi.ReadChanges(context.Background()).
+		got, response, err := apiClient.OpenFgaApi.ReadChanges(context.Background(), "01GXSB9YR785C4FYS3C0RTG7B2").
 			Type_("repo").
 			PageSize(25).
 			ContinuationToken("eyJwayI6IkxBVEVTVF9OU0NPTkZJR19hdXRoMHN0b3JlIiwic2siOiIxem1qbXF3MWZLZExTcUoyN01MdTdqTjh0cWgifQ==").
@@ -939,7 +851,7 @@ func TestOpenFgaApi(t *testing.T) {
 
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
-		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", configuration.ApiUrl, configuration.StoreId, test.RequestPath),
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", configuration.ApiUrl, "01GXSB9YR785C4FYS3C0RTG7B2", test.RequestPath),
 			func(req *http.Request) (*http.Response, error) {
 				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
 				if err != nil {
@@ -948,7 +860,7 @@ func TestOpenFgaApi(t *testing.T) {
 				return resp, nil
 			},
 		)
-		got, response, err := apiClient.OpenFgaApi.ListObjects(context.Background()).
+		got, response, err := apiClient.OpenFgaApi.ListObjects(context.Background(), "01GXSB9YR785C4FYS3C0RTG7B2").
 			Body(requestBody).
 			Execute()
 		if err != nil {
@@ -1012,7 +924,7 @@ func TestOpenFgaApi(t *testing.T) {
 
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
-		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", configuration.ApiUrl, configuration.StoreId, test.RequestPath),
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", configuration.ApiUrl, "01GXSB9YR785C4FYS3C0RTG7B2", test.RequestPath),
 			func(req *http.Request) (*http.Response, error) {
 				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
 				if err != nil {
@@ -1021,7 +933,7 @@ func TestOpenFgaApi(t *testing.T) {
 				return resp, nil
 			},
 		)
-		got, response, err := apiClient.OpenFgaApi.ListUsers(context.Background()).
+		got, response, err := apiClient.OpenFgaApi.ListUsers(context.Background(), "01GXSB9YR785C4FYS3C0RTG7B2").
 			Body(requestBody).
 			Execute()
 		if err != nil {
@@ -1079,9 +991,10 @@ func TestOpenFgaApi(t *testing.T) {
 			t.Fatalf("%v", err)
 		}
 
+		storeId := "01GXSB9YR785C4FYS3C0RTG7B2"
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
-		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", configuration.ApiUrl, configuration.StoreId, test.RequestPath),
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", configuration.ApiUrl, storeId, test.RequestPath),
 			func(req *http.Request) (*http.Response, error) {
 				errObj := ErrorResponse{
 					Code:    "validation_error",
@@ -1090,7 +1003,7 @@ func TestOpenFgaApi(t *testing.T) {
 				return httpmock.NewJsonResponse(400, errObj)
 			},
 		)
-		_, _, err := apiClient.OpenFgaApi.Check(context.Background()).Body(requestBody).Execute()
+		_, _, err := apiClient.OpenFgaApi.Check(context.Background(), storeId).Body(requestBody).Execute()
 		if err == nil {
 			t.Fatalf("Expected error with 400 request but there is none")
 		}
@@ -1100,8 +1013,8 @@ func TestOpenFgaApi(t *testing.T) {
 		}
 		// Do some basic validation of the error itself
 
-		if validationError.StoreId() != configuration.StoreId {
-			t.Fatalf("Expected store id to be %s but actual %s", configuration.StoreId, validationError.StoreId())
+		if validationError.StoreId() != storeId {
+			t.Fatalf("Expected store id to be %s but actual %s", storeId, validationError.StoreId())
 		}
 
 		if validationError.EndpointCategory() != "Check" {
@@ -1142,9 +1055,10 @@ func TestOpenFgaApi(t *testing.T) {
 			t.Fatalf("%v", err)
 		}
 
+		storeId := "01GXSB9YR785C4FYS3C0RTG7B2"
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
-		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", configuration.ApiUrl, configuration.StoreId, test.RequestPath),
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", configuration.ApiUrl, storeId, test.RequestPath),
 			func(req *http.Request) (*http.Response, error) {
 				errObj := ErrorResponse{
 					Code:    "auth_failure",
@@ -1153,7 +1067,7 @@ func TestOpenFgaApi(t *testing.T) {
 				return httpmock.NewJsonResponse(401, errObj)
 			},
 		)
-		_, _, err := apiClient.OpenFgaApi.Check(context.Background()).Body(requestBody).Execute()
+		_, _, err := apiClient.OpenFgaApi.Check(context.Background(), storeId).Body(requestBody).Execute()
 		if err == nil {
 			t.Fatalf("Expected error with 401 request but there is none")
 		}
@@ -1163,8 +1077,8 @@ func TestOpenFgaApi(t *testing.T) {
 		}
 		// Do some basic validation of the error itself
 
-		if authenticationError.StoreId() != configuration.StoreId {
-			t.Fatalf("Expected store id to be %s but actual %s", configuration.StoreId, authenticationError.StoreId())
+		if authenticationError.StoreId() != storeId {
+			t.Fatalf("Expected store id to be %s but actual %s", storeId, authenticationError.StoreId())
 		}
 
 		if authenticationError.EndpointCategory() != "Check" {
@@ -1198,9 +1112,10 @@ func TestOpenFgaApi(t *testing.T) {
 			t.Fatalf("%v", err)
 		}
 
+		storeId := "01GXSB9YR785C4FYS3C0RTG7B2"
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
-		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", configuration.ApiUrl, configuration.StoreId, test.RequestPath),
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", configuration.ApiUrl, storeId, test.RequestPath),
 			func(req *http.Request) (*http.Response, error) {
 				errObj := ErrorResponse{
 					Code:    "undefined_endpoint",
@@ -1209,7 +1124,7 @@ func TestOpenFgaApi(t *testing.T) {
 				return httpmock.NewJsonResponse(404, errObj)
 			},
 		)
-		_, _, err := apiClient.OpenFgaApi.Check(context.Background()).Body(requestBody).Execute()
+		_, _, err := apiClient.OpenFgaApi.Check(context.Background(), storeId).Body(requestBody).Execute()
 		if err == nil {
 			t.Fatalf("Expected error with 404 request but there is none")
 		}
@@ -1219,8 +1134,8 @@ func TestOpenFgaApi(t *testing.T) {
 		}
 		// Do some basic validation of the error itself
 
-		if notFoundError.StoreId() != configuration.StoreId {
-			t.Fatalf("Expected store id to be %s but actual %s", configuration.StoreId, notFoundError.StoreId())
+		if notFoundError.StoreId() != storeId {
+			t.Fatalf("Expected store id to be %s but actual %s", storeId, notFoundError.StoreId())
 		}
 
 		if notFoundError.EndpointCategory() != "Check" {
@@ -1261,9 +1176,10 @@ func TestOpenFgaApi(t *testing.T) {
 			t.Fatalf("%v", err)
 		}
 
+		storeId := "01GXSB9YR785C4FYS3C0RTG7B2"
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
-		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", configuration.ApiUrl, configuration.StoreId, test.RequestPath),
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", configuration.ApiUrl, storeId, test.RequestPath),
 			func(req *http.Request) (*http.Response, error) {
 				errObj := ErrorResponse{
 					Code:    "rate_limit_exceeded",
@@ -1275,7 +1191,6 @@ func TestOpenFgaApi(t *testing.T) {
 
 		updatedConfiguration, err := NewConfiguration(Configuration{
 			ApiHost: "api.fga.example",
-			StoreId: "01GXSB9YR785C4FYS3C0RTG7B2",
 			RetryParams: &RetryParams{
 				MaxRetry:    3,
 				MinWaitInMs: 5,
@@ -1287,7 +1202,7 @@ func TestOpenFgaApi(t *testing.T) {
 
 		updatedApiClient := NewAPIClient(updatedConfiguration)
 
-		_, _, err = updatedApiClient.OpenFgaApi.Check(context.Background()).Body(requestBody).Execute()
+		_, _, err = updatedApiClient.OpenFgaApi.Check(context.Background(), storeId).Body(requestBody).Execute()
 		if err == nil {
 			t.Fatalf("Expected error with 429 request but there is none")
 		}
@@ -1297,8 +1212,8 @@ func TestOpenFgaApi(t *testing.T) {
 		}
 		// Do some basic validation of the error itself
 
-		if rateLimitError.StoreId() != configuration.StoreId {
-			t.Fatalf("Expected store id to be %s but actual %s", configuration.StoreId, rateLimitError.StoreId())
+		if rateLimitError.StoreId() != storeId {
+			t.Fatalf("Expected store id to be %s but actual %s", storeId, rateLimitError.StoreId())
 		}
 
 		if rateLimitError.EndpointCategory() != "Check" {
@@ -1336,12 +1251,11 @@ func TestOpenFgaApi(t *testing.T) {
 		defer httpmock.DeactivateAndReset()
 		firstMock := httpmock.NewStringResponder(429, "")
 		secondMock, _ := httpmock.NewJsonResponder(200, expectedResponse)
-		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", configuration.ApiUrl, configuration.StoreId, test.RequestPath),
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", configuration.ApiUrl, "01GXSB9YR785C4FYS3C0RTG7B2", test.RequestPath),
 			firstMock.Then(firstMock).Then(firstMock).Then(secondMock),
 		)
 		updatedConfiguration, err := NewConfiguration(Configuration{
 			ApiHost: "api.fga.example",
-			StoreId: "01GXSB9YR785C4FYS3C0RTG7B2",
 			RetryParams: &RetryParams{
 				MaxRetry:    2,
 				MinWaitInMs: 5,
@@ -1353,7 +1267,7 @@ func TestOpenFgaApi(t *testing.T) {
 
 		updatedApiClient := NewAPIClient(updatedConfiguration)
 
-		got, response, err := updatedApiClient.OpenFgaApi.Check(context.Background()).Body(requestBody).Execute()
+		got, response, err := updatedApiClient.OpenFgaApi.Check(context.Background(), "01GXSB9YR785C4FYS3C0RTG7B2").Body(requestBody).Execute()
 
 		if err != nil {
 			t.Fatalf("%v", err)
@@ -1394,9 +1308,10 @@ func TestOpenFgaApi(t *testing.T) {
 			t.Fatalf("%v", err)
 		}
 
+		storeId := "01GXSB9YR785C4FYS3C0RTG7B2"
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
-		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", configuration.ApiUrl, configuration.StoreId, test.RequestPath),
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", configuration.ApiUrl, storeId, test.RequestPath),
 			func(req *http.Request) (*http.Response, error) {
 				errObj := ErrorResponse{
 					Code:    "internal_error",
@@ -1405,7 +1320,7 @@ func TestOpenFgaApi(t *testing.T) {
 				return httpmock.NewJsonResponse(500, errObj)
 			},
 		)
-		_, _, err := apiClient.OpenFgaApi.Check(context.Background()).Body(requestBody).Execute()
+		_, _, err := apiClient.OpenFgaApi.Check(context.Background(), storeId).Body(requestBody).Execute()
 		if err == nil {
 			t.Fatalf("Expected error with 500 request but there is none")
 		}
@@ -1415,8 +1330,8 @@ func TestOpenFgaApi(t *testing.T) {
 		}
 		// Do some basic validation of the error itself
 
-		if internalError.StoreId() != configuration.StoreId {
-			t.Fatalf("Expected store id to be %s but actual %s", configuration.StoreId, internalError.StoreId())
+		if internalError.StoreId() != storeId {
+			t.Fatalf("Expected store id to be %s but actual %s", storeId, internalError.StoreId())
 		}
 
 		if internalError.EndpointCategory() != "Check" {

--- a/client/client.go
+++ b/client/client.go
@@ -94,11 +94,11 @@ func NewSdkClient(cfg *ClientConfiguration) (*OpenFgaClient, error) {
 	// store id is already validate as part of configuration validation
 
 	if cfg.AuthorizationModelId != "" && !internalutils.IsWellFormedUlidString(cfg.AuthorizationModelId) {
-		return nil, FgaInvalidError{param: "AuthorizationModelId", description: "ULID"}
+		return nil, FgaInvalidError{param: "AuthorizationModelId", description: "Expected ULID format"}
 	}
 
 	if cfg.StoreId != "" && !internalutils.IsWellFormedUlidString(cfg.StoreId) {
-		return nil, FgaInvalidError{param: "StoreId", description: "ULID"}
+		return nil, FgaInvalidError{param: "StoreId", description: "Expected ULID format"}
 	}
 
 	apiClient := fgaSdk.NewAPIClient(apiConfiguration)
@@ -435,7 +435,7 @@ type SdkClient interface {
 
 func (client *OpenFgaClient) SetAuthorizationModelId(authorizationModelId string) error {
 	if authorizationModelId != "" && !internalutils.IsWellFormedUlidString(authorizationModelId) {
-		return FgaInvalidError{param: "AuthorizationModelId", description: "ULID"}
+		return FgaInvalidError{param: "AuthorizationModelId", description: "Expected ULID format"}
 	}
 
 	client.config.AuthorizationModelId = authorizationModelId
@@ -446,7 +446,7 @@ func (client *OpenFgaClient) SetAuthorizationModelId(authorizationModelId string
 func (client *OpenFgaClient) GetAuthorizationModelId() (string, error) {
 	modelId := client.config.AuthorizationModelId
 	if modelId != "" && !internalutils.IsWellFormedUlidString(modelId) {
-		return "", FgaInvalidError{param: "AuthorizationModelId", description: "ULID"}
+		return "", FgaInvalidError{param: "AuthorizationModelId", description: "Expected ULID format"}
 	}
 
 	return modelId, nil
@@ -459,14 +459,14 @@ func (client *OpenFgaClient) getAuthorizationModelId(authorizationModelId *strin
 	}
 
 	if modelId != "" && !internalutils.IsWellFormedUlidString(modelId) {
-		return nil, FgaInvalidError{param: "AuthorizationModelId", description: "ULID"}
+		return nil, FgaInvalidError{param: "AuthorizationModelId", description: "Expected ULID format"}
 	}
 	return &modelId, nil
 }
 
 func (client *OpenFgaClient) SetStoreId(storeId string) error {
 	if storeId != "" && !internalutils.IsWellFormedUlidString(storeId) {
-		return FgaInvalidError{param: "StoreId", description: "ULID"}
+		return FgaInvalidError{param: "StoreId", description: "Expected ULID format"}
 	}
 	client.config.StoreId = storeId
 	return nil
@@ -475,7 +475,7 @@ func (client *OpenFgaClient) SetStoreId(storeId string) error {
 func (client *OpenFgaClient) GetStoreId() (string, error) {
 	storeId := client.config.StoreId
 	if storeId != "" && !internalutils.IsWellFormedUlidString(storeId) {
-		return "", FgaInvalidError{param: "StoreId", description: "ULID"}
+		return "", FgaInvalidError{param: "StoreId", description: "Expected ULID format"}
 	}
 	return storeId, nil
 }
@@ -486,7 +486,7 @@ func (client *OpenFgaClient) getStoreId(storeId *string) (*string, error) {
 		store = *storeId
 	}
 	if store != "" && !internalutils.IsWellFormedUlidString(store) {
-		return nil, FgaInvalidError{param: "StoreId", description: "ULID"}
+		return nil, FgaInvalidError{param: "StoreId", description: "Expected ULID format"}
 	}
 
 	return &store, nil

--- a/client/client.go
+++ b/client/client.go
@@ -2283,6 +2283,7 @@ type ClientListRelationsRequest struct {
 
 type ClientListRelationsOptions struct {
 	AuthorizationModelId *string `json:"authorization_model_id,omitempty"`
+	MaxParallelRequests  *int32  `json:"max_parallel_requests,omitempty"`
 	StoreId              *string `json:"store_id,omitempty"`
 }
 
@@ -2366,6 +2367,10 @@ func (client *OpenFgaClient) ListRelationsExecute(request SdkClientListRelations
 	if err != nil {
 		return nil, err
 	}
+	var maxParallelReqs *int32
+	if request.GetOptions() != nil {
+		maxParallelReqs = request.GetOptions().MaxParallelRequests
+	}
 	batchResponse, err := client.BatchCheckExecute(&SdkClientBatchCheckRequest{
 		ctx:    request.GetContext(),
 		Client: client,
@@ -2373,6 +2378,7 @@ func (client *OpenFgaClient) ListRelationsExecute(request SdkClientListRelations
 		options: &ClientBatchCheckOptions{
 			AuthorizationModelId: authorizationModelId,
 			StoreId:              storeId,
+			MaxParallelRequests:  maxParallelReqs,
 		},
 	})
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"github.com/jarcoal/httpmock"
-	openfga "github.com/openfga/go-sdk"
+	"github.com/openfga/go-sdk"
 	. "github.com/openfga/go-sdk/client"
 )
 
@@ -276,7 +276,7 @@ func TestOpenFgaClient(t *testing.T) {
 
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
-		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s", fgaClient.GetConfig().ApiUrl, fgaClient.GetConfig().StoreId),
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s", fgaClient.GetConfig().ApiUrl, getStoreId(t, fgaClient)),
 			func(req *http.Request) (*http.Response, error) {
 				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
 				if err != nil {
@@ -299,6 +299,36 @@ func TestOpenFgaClient(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%v", err)
 		}
+
+		// invalid store id should result in error
+		badStoreOptions := ClientGetStoreOptions{
+			StoreId: openfga.PtrString("INVALID"),
+		}
+		_, err = fgaClient.GetStore(context.Background()).Options(badStoreOptions).Execute()
+		if err == nil {
+			t.Fatalf("Expect error with bad store id but there is none")
+		}
+
+		// store can be overridden
+		storeOverrideOptions := ClientGetStoreOptions{
+			StoreId: openfga.PtrString("7777HCE4YVKPQEKZQHT2R89MQV"),
+		}
+		httpmock.Reset()
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s", fgaClient.GetConfig().ApiUrl, *storeOverrideOptions.StoreId),
+			func(req *http.Request) (*http.Response, error) {
+				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
+				if err != nil {
+					return httpmock.NewStringResponse(http.StatusInternalServerError, ""), nil
+				}
+				return resp, nil
+			},
+		)
+
+		_, err = fgaClient.GetStore(context.Background()).Options(storeOverrideOptions).Execute()
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+
 	})
 
 	t.Run("GetStoreAfterSettingStoreId", func(t *testing.T) {
@@ -378,7 +408,7 @@ func TestOpenFgaClient(t *testing.T) {
 
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
-		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s", fgaClient.GetConfig().ApiUrl, fgaClient.GetConfig().StoreId),
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s", fgaClient.GetConfig().ApiUrl, getStoreId(t, fgaClient)),
 			func(req *http.Request) (*http.Response, error) {
 				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, "{}")
 				if err != nil {
@@ -393,6 +423,34 @@ func TestOpenFgaClient(t *testing.T) {
 		}
 		// DeleteStore without options should work
 		_, err = fgaClient.DeleteStore(context.Background()).Execute()
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+
+		// invalid store id should result in error
+		badStoreOptions := ClientDeleteStoreOptions{
+			StoreId: openfga.PtrString("INVALID"),
+		}
+		_, err = fgaClient.DeleteStore(context.Background()).Options(badStoreOptions).Execute()
+		if err == nil {
+			t.Fatalf("Expect error with bad store id but there is none")
+		}
+
+		// store can be overridden
+		storeOverrideOptions := ClientDeleteStoreOptions{
+			StoreId: openfga.PtrString("7777HCE4YVKPQEKZQHT2R89MQV"),
+		}
+		httpmock.Reset()
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s", fgaClient.GetConfig().ApiUrl, *storeOverrideOptions.StoreId),
+			func(req *http.Request) (*http.Response, error) {
+				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, "{}")
+				if err != nil {
+					return httpmock.NewStringResponse(http.StatusInternalServerError, ""), nil
+				}
+				return resp, nil
+			},
+		)
+		_, err = fgaClient.DeleteStore(context.Background()).Options(storeOverrideOptions).Execute()
 		if err != nil {
 			t.Fatalf("%v", err)
 		}
@@ -415,7 +473,7 @@ func TestOpenFgaClient(t *testing.T) {
 
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
-		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, fgaClient.GetConfig().StoreId, test.RequestPath),
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, getStoreId(t, fgaClient), test.RequestPath),
 			func(req *http.Request) (*http.Response, error) {
 				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
 				if err != nil {
@@ -443,6 +501,34 @@ func TestOpenFgaClient(t *testing.T) {
 		}
 		// ReadAuthorizationModels without options should work
 		_, err = fgaClient.ReadAuthorizationModels(context.Background()).Execute()
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+
+		// invalid store id should result in error
+		badStoreOptions := ClientReadAuthorizationModelsOptions{
+			StoreId: openfga.PtrString("INVALID"),
+		}
+		_, err = fgaClient.ReadAuthorizationModels(context.Background()).Options(badStoreOptions).Execute()
+		if err == nil {
+			t.Fatalf("Expect error with bad store id but there is none")
+		}
+
+		// store can be overridden
+		storeOverrideOptions := ClientReadAuthorizationModelsOptions{
+			StoreId: openfga.PtrString("7777HCE4YVKPQEKZQHT2R89MQV"),
+		}
+		httpmock.Reset()
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, *storeOverrideOptions.StoreId, test.RequestPath),
+			func(req *http.Request) (*http.Response, error) {
+				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
+				if err != nil {
+					return httpmock.NewStringResponse(http.StatusInternalServerError, ""), nil
+				}
+				return resp, nil
+			},
+		)
+		_, err = fgaClient.ReadAuthorizationModels(context.Background()).Options(storeOverrideOptions).Execute()
 		if err != nil {
 			t.Fatalf("%v", err)
 		}
@@ -500,7 +586,7 @@ func TestOpenFgaClient(t *testing.T) {
 
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
-		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, fgaClient.GetConfig().StoreId, test.RequestPath),
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, getStoreId(t, fgaClient), test.RequestPath),
 			func(req *http.Request) (*http.Response, error) {
 				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
 				if err != nil {
@@ -526,6 +612,34 @@ func TestOpenFgaClient(t *testing.T) {
 
 		// WriteAuthorizationModel without options should work
 		_, err = fgaClient.WriteAuthorizationModel(context.Background()).Body(requestBody).Execute()
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+
+		// invalid store id should result in error
+		badStoreOptions := ClientWriteAuthorizationModelOptions{
+			StoreId: openfga.PtrString("INVALID"),
+		}
+		_, err = fgaClient.WriteAuthorizationModel(context.Background()).Body(requestBody).Options(badStoreOptions).Execute()
+		if err == nil {
+			t.Fatalf("%v", err)
+		}
+
+		// store can be overridden
+		storeOverrideOptions := ClientWriteAuthorizationModelOptions{
+			StoreId: openfga.PtrString("7777HCE4YVKPQEKZQHT2R89MQV"),
+		}
+		httpmock.Reset()
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, *storeOverrideOptions.StoreId, test.RequestPath),
+			func(req *http.Request) (*http.Response, error) {
+				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
+				if err != nil {
+					return httpmock.NewStringResponse(http.StatusInternalServerError, ""), nil
+				}
+				return resp, nil
+			},
+		)
+		_, err = fgaClient.WriteAuthorizationModel(context.Background()).Body(requestBody).Options(storeOverrideOptions).Execute()
 		if err != nil {
 			t.Fatalf("%v", err)
 		}
@@ -605,7 +719,7 @@ func TestOpenFgaClient(t *testing.T) {
 		defer httpmock.DeactivateAndReset()
 		httpmock.RegisterMatcherResponder(
 			test.Method,
-			fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, fgaClient.GetConfig().StoreId, test.RequestPath),
+			fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, getStoreId(t, fgaClient), test.RequestPath),
 			httpmock.BodyContainsString(`"ViewCountLessThan200"`),
 			func(req *http.Request) (*http.Response, error) {
 				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
@@ -715,7 +829,7 @@ func TestOpenFgaClient(t *testing.T) {
 		defer httpmock.DeactivateAndReset()
 		httpmock.RegisterMatcherResponder(
 			test.Method,
-			fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, fgaClient.GetConfig().StoreId, test.RequestPath),
+			fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, getStoreId(t, fgaClient), test.RequestPath),
 			httpmock.BodyContainsString(`"ViewCountLessThan200"`),
 			func(req *http.Request) (*http.Response, error) {
 				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
@@ -764,7 +878,7 @@ func TestOpenFgaClient(t *testing.T) {
 
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
-		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s/%s", fgaClient.GetConfig().ApiUrl, fgaClient.GetConfig().StoreId, test.RequestPath, modelId),
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s/%s", fgaClient.GetConfig().ApiUrl, getStoreId(t, fgaClient), test.RequestPath, modelId),
 			func(req *http.Request) (*http.Response, error) {
 				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
 				if err != nil {
@@ -803,6 +917,35 @@ func TestOpenFgaClient(t *testing.T) {
 		if err == nil || err.Error() != expectedError {
 			t.Fatalf("Expected error:%v, got: %v", expectedError, err)
 		}
+
+		// invalid store id should result in error
+		badStoreOptions := ClientReadAuthorizationModelOptions{
+			StoreId: openfga.PtrString("INVALID"),
+		}
+		_, err = fgaClient.ReadAuthorizationModel(context.Background()).Options(badStoreOptions).Execute()
+		if err == nil {
+			t.Fatalf("Expect error with bad store id but there is none")
+		}
+
+		// store can be overridden
+		storeOverrideOptions := ClientReadAuthorizationModelOptions{
+			AuthorizationModelId: openfga.PtrString(modelId),
+			StoreId:              openfga.PtrString("7777HCE4YVKPQEKZQHT2R89MQV"),
+		}
+		httpmock.Reset()
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s/%s", fgaClient.GetConfig().ApiUrl, *storeOverrideOptions.StoreId, test.RequestPath, modelId),
+			func(req *http.Request) (*http.Response, error) {
+				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
+				if err != nil {
+					return httpmock.NewStringResponse(http.StatusInternalServerError, ""), nil
+				}
+				return resp, nil
+			},
+		)
+		_, err = fgaClient.ReadAuthorizationModel(context.Background()).Options(storeOverrideOptions).Execute()
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
 	})
 
 	t.Run("ReadLatestAuthorizationModel", func(t *testing.T) {
@@ -822,7 +965,7 @@ func TestOpenFgaClient(t *testing.T) {
 
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
-		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, fgaClient.GetConfig().StoreId, test.RequestPath),
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, getStoreId(t, fgaClient), test.RequestPath),
 			func(req *http.Request) (*http.Response, error) {
 				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
 				if err != nil {
@@ -850,6 +993,34 @@ func TestOpenFgaClient(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%v", err)
 		}
+
+		// invalid store id should result in error
+		badStoreOptions := ClientReadLatestAuthorizationModelOptions{
+			StoreId: openfga.PtrString("INVALID"),
+		}
+		_, err = fgaClient.ReadLatestAuthorizationModel(context.Background()).Options(badStoreOptions).Execute()
+		if err == nil {
+			t.Fatalf("Expect error with bad store id but there is none")
+		}
+
+		// store can be overridden
+		storeOverrideOptions := ClientReadLatestAuthorizationModelOptions{
+			StoreId: openfga.PtrString("7777HCE4YVKPQEKZQHT2R89MQV"),
+		}
+		httpmock.Reset()
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, *storeOverrideOptions.StoreId, test.RequestPath),
+			func(req *http.Request) (*http.Response, error) {
+				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
+				if err != nil {
+					return httpmock.NewStringResponse(http.StatusInternalServerError, ""), nil
+				}
+				return resp, nil
+			},
+		)
+		_, err = fgaClient.ReadLatestAuthorizationModel(context.Background()).Options(storeOverrideOptions).Execute()
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
 	})
 
 	/* Relationship Tuples */
@@ -869,7 +1040,7 @@ func TestOpenFgaClient(t *testing.T) {
 
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
-		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, fgaClient.GetConfig().StoreId, test.RequestPath),
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, getStoreId(t, fgaClient), test.RequestPath),
 			func(req *http.Request) (*http.Response, error) {
 				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
 				if err != nil {
@@ -900,6 +1071,34 @@ func TestOpenFgaClient(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%v", err)
 		}
+
+		// invalid store id should result in error
+		badStoreOptions := ClientReadChangesOptions{
+			StoreId: openfga.PtrString("INVALID"),
+		}
+		_, err = fgaClient.ReadChanges(context.Background()).Body(body).Options(badStoreOptions).Execute()
+		if err == nil {
+			t.Fatalf("Expect error with bad store id but there is none")
+		}
+
+		// store can be overridden
+		storeOverrideOptions := ClientReadChangesOptions{
+			StoreId: openfga.PtrString("7777HCE4YVKPQEKZQHT2R89MQV"),
+		}
+		httpmock.Reset()
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, *storeOverrideOptions.StoreId, test.RequestPath),
+			func(req *http.Request) (*http.Response, error) {
+				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
+				if err != nil {
+					return httpmock.NewStringResponse(http.StatusInternalServerError, ""), nil
+				}
+				return resp, nil
+			},
+		)
+		_, err = fgaClient.ReadChanges(context.Background()).Body(body).Options(storeOverrideOptions).Execute()
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
 	})
 
 	t.Run("Read", func(t *testing.T) {
@@ -924,7 +1123,7 @@ func TestOpenFgaClient(t *testing.T) {
 
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
-		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, fgaClient.GetConfig().StoreId, test.RequestPath),
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, getStoreId(t, fgaClient), test.RequestPath),
 			func(req *http.Request) (*http.Response, error) {
 				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
 				if err != nil {
@@ -953,6 +1152,34 @@ func TestOpenFgaClient(t *testing.T) {
 		}
 		// Read without options should work
 		_, err = fgaClient.Read(context.Background()).Body(requestBody).Execute()
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+
+		// invalid store id should result in error
+		badStoreOptions := ClientReadOptions{
+			StoreId: openfga.PtrString("INVALID"),
+		}
+		_, err = fgaClient.Read(context.Background()).Body(requestBody).Options(badStoreOptions).Execute()
+		if err == nil {
+			t.Fatalf("Expect error with bad store id but there is none")
+		}
+
+		// store can be overridden
+		storeOverrideOptions := ClientReadOptions{
+			StoreId: openfga.PtrString("7777HCE4YVKPQEKZQHT2R89MQV"),
+		}
+		httpmock.Reset()
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, *storeOverrideOptions.StoreId, test.RequestPath),
+			func(req *http.Request) (*http.Response, error) {
+				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
+				if err != nil {
+					return httpmock.NewStringResponse(http.StatusInternalServerError, ""), nil
+				}
+				return resp, nil
+			},
+		)
+		_, err = fgaClient.Read(context.Background()).Body(requestBody).Options(storeOverrideOptions).Execute()
 		if err != nil {
 			t.Fatalf("%v", err)
 		}
@@ -985,7 +1212,7 @@ func TestOpenFgaClient(t *testing.T) {
 
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
-		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, fgaClient.GetConfig().StoreId, test.RequestPath),
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, getStoreId(t, fgaClient), test.RequestPath),
 			func(req *http.Request) (*http.Response, error) {
 				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
 				if err != nil {
@@ -1041,6 +1268,25 @@ func TestOpenFgaClient(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%v", err)
 		}
+
+		// store ID can be overridden
+		storeOverrideOptions := ClientWriteOptions{
+			StoreId: openfga.PtrString("7777HCE4YVKPQEKZQHT2R89MQV"),
+		}
+		httpmock.Reset()
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, *storeOverrideOptions.StoreId, test.RequestPath),
+			func(req *http.Request) (*http.Response, error) {
+				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
+				if err != nil {
+					return httpmock.NewStringResponse(http.StatusInternalServerError, ""), nil
+				}
+				return resp, nil
+			},
+		)
+		_, err = fgaClient.Write(context.Background()).Body(requestBody).Options(storeOverrideOptions).Execute()
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
 	})
 
 	t.Run("Write with invalid auth model id", func(t *testing.T) {
@@ -1070,6 +1316,36 @@ func TestOpenFgaClient(t *testing.T) {
 		_, err := fgaClient.Write(context.Background()).Body(requestBody).Options(options).Execute()
 		if err == nil {
 			t.Fatalf("Expect error due to invalid auth model ID but there is none")
+		}
+	})
+
+	t.Run("Write with invalid store id", func(t *testing.T) {
+		test := TestDefinition{
+			Name:           "Write",
+			JsonResponse:   `{}`,
+			ResponseStatus: http.StatusOK,
+			Method:         http.MethodPost,
+			RequestPath:    "write",
+		}
+		requestBody := ClientWriteRequest{
+			Writes: []ClientTupleKey{{
+				User:     "user:81684243-9356-4421-8fbf-a4f8d36aa31b",
+				Relation: "viewer",
+				Object:   "document:roadmap",
+			}},
+		}
+		options := ClientWriteOptions{
+			StoreId: openfga.PtrString("INVALID"),
+		}
+
+		var expectedResponse map[string]interface{}
+		if err := json.Unmarshal([]byte(test.JsonResponse), &expectedResponse); err != nil {
+			t.Fatalf("%v", err)
+		}
+
+		_, err := fgaClient.Write(context.Background()).Body(requestBody).Options(options).Execute()
+		if err == nil {
+			t.Fatalf("Expect error due to invalid store ID but there is none")
 		}
 	})
 
@@ -1114,7 +1390,7 @@ func TestOpenFgaClient(t *testing.T) {
 
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
-		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, fgaClient.GetConfig().StoreId, test.RequestPath),
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, getStoreId(t, fgaClient), test.RequestPath),
 			func(req *http.Request) (*http.Response, error) {
 				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
 				if err != nil {
@@ -1189,7 +1465,7 @@ func TestOpenFgaClient(t *testing.T) {
 
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
-		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, fgaClient.GetConfig().StoreId, test.RequestPath),
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, getStoreId(t, fgaClient), test.RequestPath),
 			func(req *http.Request) (*http.Response, error) {
 				return httpmock.NewStringResponse(http.StatusUnauthorized, ""), nil
 			},
@@ -1230,7 +1506,7 @@ func TestOpenFgaClient(t *testing.T) {
 
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
-		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, fgaClient.GetConfig().StoreId, test.RequestPath),
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, getStoreId(t, fgaClient), test.RequestPath),
 			func(req *http.Request) (*http.Response, error) {
 				return httpmock.NewStringResponse(http.StatusUnauthorized, ""), nil
 			},
@@ -1289,7 +1565,7 @@ func TestOpenFgaClient(t *testing.T) {
 
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
-		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, fgaClient.GetConfig().StoreId, test.RequestPath),
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, getStoreId(t, fgaClient), test.RequestPath),
 			func(req *http.Request) (*http.Response, error) {
 				return httpmock.NewStringResponse(http.StatusBadRequest, ""), nil
 			},
@@ -1346,7 +1622,7 @@ func TestOpenFgaClient(t *testing.T) {
 
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
-		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, fgaClient.GetConfig().StoreId, test.RequestPath),
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, getStoreId(t, fgaClient), test.RequestPath),
 			func(req *http.Request) (*http.Response, error) {
 				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
 				if err != nil {
@@ -1402,6 +1678,34 @@ func TestOpenFgaClient(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%v", err)
 		}
+
+		// invalid store id should result in error
+		badStoreOptions := ClientWriteOptions{
+			StoreId: openfga.PtrString("INVALID"),
+		}
+		_, err = fgaClient.WriteTuples(context.Background()).Body(requestBody).Options(badStoreOptions).Execute()
+		if err == nil {
+			t.Fatalf("Expect error with bad store id but there is none")
+		}
+
+		// store can be overridden
+		storeOverrideOptions := ClientWriteOptions{
+			StoreId: openfga.PtrString("7777HCE4YVKPQEKZQHT2R89MQV"),
+		}
+		httpmock.Reset()
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, *storeOverrideOptions.StoreId, test.RequestPath),
+			func(req *http.Request) (*http.Response, error) {
+				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
+				if err != nil {
+					return httpmock.NewStringResponse(http.StatusInternalServerError, ""), nil
+				}
+				return resp, nil
+			},
+		)
+		_, err = fgaClient.WriteTuples(context.Background()).Body(requestBody).Options(storeOverrideOptions).Execute()
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
 	})
 
 	t.Run("DeleteTuples", func(t *testing.T) {
@@ -1429,7 +1733,7 @@ func TestOpenFgaClient(t *testing.T) {
 
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
-		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, fgaClient.GetConfig().StoreId, test.RequestPath),
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, getStoreId(t, fgaClient), test.RequestPath),
 			func(req *http.Request) (*http.Response, error) {
 				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
 				if err != nil {
@@ -1485,6 +1789,34 @@ func TestOpenFgaClient(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%v", err)
 		}
+
+		// invalid store id should result in error
+		badStoreOptions := ClientWriteOptions{
+			StoreId: openfga.PtrString("INVALID"),
+		}
+		_, err = fgaClient.DeleteTuples(context.Background()).Body(requestBody).Options(badStoreOptions).Execute()
+		if err == nil {
+			t.Fatalf("Expect error with bad store id but there is none")
+		}
+
+		// store can be overridden
+		storeOverrideOptions := ClientWriteOptions{
+			StoreId: openfga.PtrString("7777HCE4YVKPQEKZQHT2R89MQV"),
+		}
+		httpmock.Reset()
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, *storeOverrideOptions.StoreId, test.RequestPath),
+			func(req *http.Request) (*http.Response, error) {
+				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
+				if err != nil {
+					return httpmock.NewStringResponse(http.StatusInternalServerError, ""), nil
+				}
+				return resp, nil
+			},
+		)
+		_, err = fgaClient.DeleteTuples(context.Background()).Body(requestBody).Options(storeOverrideOptions).Execute()
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
 	})
 
 	/* Relationship Queries */
@@ -1518,7 +1850,7 @@ func TestOpenFgaClient(t *testing.T) {
 
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
-		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, fgaClient.GetConfig().StoreId, test.RequestPath),
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, getStoreId(t, fgaClient), test.RequestPath),
 			func(req *http.Request) (*http.Response, error) {
 				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
 				if err != nil {
@@ -1553,6 +1885,33 @@ func TestOpenFgaClient(t *testing.T) {
 		_, err = fgaClient.Check(context.Background()).Body(requestBody).Options(badOptions).Execute()
 		if err == nil {
 			t.Fatalf("Expect error with bad auth model id but there is none")
+		}
+		// invalid store id should result in error
+		badStoreOptions := ClientCheckOptions{
+			StoreId: openfga.PtrString("INVALID"),
+		}
+		_, err = fgaClient.Check(context.Background()).Body(requestBody).Options(badStoreOptions).Execute()
+		if err == nil {
+			t.Fatalf("Expect error with bad store id but there is none")
+		}
+
+		// store can be overridden
+		storeOverrideOptions := ClientCheckOptions{
+			StoreId: openfga.PtrString("7777HCE4YVKPQEKZQHT2R89MQV"),
+		}
+		httpmock.Reset()
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, *storeOverrideOptions.StoreId, test.RequestPath),
+			func(req *http.Request) (*http.Response, error) {
+				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
+				if err != nil {
+					return httpmock.NewStringResponse(http.StatusInternalServerError, ""), nil
+				}
+				return resp, nil
+			},
+		)
+		_, err = fgaClient.Check(context.Background()).Body(requestBody).Options(storeOverrideOptions).Execute()
+		if err != nil {
+			t.Fatalf("%v", err)
 		}
 
 	})
@@ -1607,7 +1966,7 @@ func TestOpenFgaClient(t *testing.T) {
 
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
-		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, fgaClient.GetConfig().StoreId, test.RequestPath),
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, getStoreId(t, fgaClient), test.RequestPath),
 			func(req *http.Request) (*http.Response, error) {
 				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
 				if err != nil {
@@ -1623,7 +1982,7 @@ func TestOpenFgaClient(t *testing.T) {
 		}
 
 		if httpmock.GetTotalCallCount() != 4 {
-			t.Fatalf("OpenFgaClient.%v() - wanted %v calls to /check got %v", test.Name, 4, httpmock.GetTotalCallCount())
+			t.Fatalf("OpenFgaClient.%v() - wanted %v calls to /check, got %v", test.Name, 4, httpmock.GetTotalCallCount())
 		}
 
 		if len(*got) != len(requestBody) {
@@ -1664,13 +2023,22 @@ func TestOpenFgaClient(t *testing.T) {
 		if err == nil {
 			t.Fatalf("Expect error with invalid auth model id but there is none")
 		}
+		// invalid store ID should fail
+		badStoreOptions := ClientBatchCheckOptions{
+			StoreId:             openfga.PtrString("INVALID"),
+			MaxParallelRequests: openfga.PtrInt32(5),
+		}
+		_, err = fgaClient.BatchCheck(context.Background()).Body(requestBody).Options(badStoreOptions).Execute()
+		if err == nil {
+			t.Fatalf("Expect error with invalid auth model id but there is none")
+		}
 
 		if httpmock.GetTotalCallCount() != 0 {
 			t.Fatalf("Expected no calls to be made")
 		}
 
 		httpmock.ZeroCallCounters()
-		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, fgaClient.GetConfig().StoreId, test.RequestPath),
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, getStoreId(t, fgaClient), test.RequestPath),
 			func(req *http.Request) (*http.Response, error) {
 				return httpmock.NewStringResponse(http.StatusUnauthorized, ""), nil
 			},
@@ -1679,6 +2047,26 @@ func TestOpenFgaClient(t *testing.T) {
 		_, err = fgaClient.BatchCheck(context.Background()).Body(requestBody).Options(options).Execute()
 		if err == nil {
 			t.Fatalf("Expect error with invalid auth but there is none")
+		}
+
+		// store should be overridden
+		storeOverrideOptions := ClientBatchCheckOptions{
+			StoreId:             openfga.PtrString("7777HCE4YVKPQEKZQHT2R89MQV"),
+			MaxParallelRequests: openfga.PtrInt32(5),
+		}
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, *storeOverrideOptions.StoreId, test.RequestPath),
+			func(req *http.Request) (*http.Response, error) {
+				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
+				if err != nil {
+					return httpmock.NewStringResponse(http.StatusInternalServerError, ""), nil
+				}
+				return resp, nil
+			},
+		)
+
+		_, err = fgaClient.BatchCheck(context.Background()).Body(requestBody).Options(storeOverrideOptions).Execute()
+		if err != nil {
+			t.Fatalf("%v", err)
 		}
 	})
 
@@ -1706,7 +2094,7 @@ func TestOpenFgaClient(t *testing.T) {
 
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
-		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, fgaClient.GetConfig().StoreId, test.RequestPath),
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, getStoreId(t, fgaClient), test.RequestPath),
 			func(req *http.Request) (*http.Response, error) {
 				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
 				if err != nil {
@@ -1736,6 +2124,34 @@ func TestOpenFgaClient(t *testing.T) {
 		_, err = fgaClient.Expand(context.Background()).Body(requestBody).Options(badOptions).Execute()
 		if err == nil {
 			t.Fatalf("Expect error for invalid auth model id but there is none")
+		}
+
+		// Invalid auth model ID should result in error
+		badStoreOptions := ClientExpandOptions{
+			StoreId: openfga.PtrString("INVALID"),
+		}
+		_, err = fgaClient.Expand(context.Background()).Body(requestBody).Options(badStoreOptions).Execute()
+		if err == nil {
+			t.Fatalf("Expect error for invalid auth model id but there is none")
+		}
+
+		// store can be overridden
+		storeOverrideOptions := ClientExpandOptions{
+			StoreId: openfga.PtrString("7777HCE4YVKPQEKZQHT2R89MQV"),
+		}
+		httpmock.Reset()
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, *storeOverrideOptions.StoreId, test.RequestPath),
+			func(req *http.Request) (*http.Response, error) {
+				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
+				if err != nil {
+					return httpmock.NewStringResponse(http.StatusInternalServerError, ""), nil
+				}
+				return resp, nil
+			},
+		)
+		_, err = fgaClient.Expand(context.Background()).Body(requestBody).Options(storeOverrideOptions).Execute()
+		if err != nil {
+			t.Fatalf("%v", err)
 		}
 	})
 
@@ -1773,7 +2189,7 @@ func TestOpenFgaClient(t *testing.T) {
 
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
-		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, fgaClient.GetConfig().StoreId, test.RequestPath),
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, getStoreId(t, fgaClient), test.RequestPath),
 			func(req *http.Request) (*http.Response, error) {
 				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
 				if err != nil {
@@ -1803,6 +2219,7 @@ func TestOpenFgaClient(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%v", err)
 		}
+
 		// Invalid auth model id should result in error
 		badOptions := ClientListObjectsOptions{
 			AuthorizationModelId: openfga.PtrString("INVALID"),
@@ -1813,6 +2230,39 @@ func TestOpenFgaClient(t *testing.T) {
 			Execute()
 		if err == nil {
 			t.Fatalf("Expect error with invalid auth model id but there is none")
+		}
+		// Invalid store id should result in error
+		badStoreOptions := ClientListObjectsOptions{
+			StoreId: openfga.PtrString("INVALID"),
+		}
+		_, err = fgaClient.ListObjects(context.Background()).
+			Body(requestBody).
+			Options(badStoreOptions).
+			Execute()
+		if err == nil {
+			t.Fatalf("Expect error with invalid auth model id but there is none")
+		}
+
+		// store can be overridden
+		storeOverrideOptions := ClientListObjectsOptions{
+			StoreId: openfga.PtrString("7777HCE4YVKPQEKZQHT2R89MQV"),
+		}
+		httpmock.Reset()
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, *storeOverrideOptions.StoreId, test.RequestPath),
+			func(req *http.Request) (*http.Response, error) {
+				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
+				if err != nil {
+					return httpmock.NewStringResponse(http.StatusInternalServerError, ""), nil
+				}
+				return resp, nil
+			},
+		)
+		_, err = fgaClient.ListObjects(context.Background()).
+			Body(requestBody).
+			Options(storeOverrideOptions).
+			Execute()
+		if err != nil {
+			t.Fatalf("%v", err)
 		}
 	})
 
@@ -1847,7 +2297,7 @@ func TestOpenFgaClient(t *testing.T) {
 
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
-		httpmock.RegisterMatcherResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, fgaClient.GetConfig().StoreId, test.RequestPath),
+		httpmock.RegisterMatcherResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, getStoreId(t, fgaClient), test.RequestPath),
 			httpmock.BodyContainsString(`"relation":"can_delete"`),
 			func(req *http.Request) (*http.Response, error) {
 				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, openfga.CheckResponse{Allowed: openfga.PtrBool(false)})
@@ -1857,7 +2307,7 @@ func TestOpenFgaClient(t *testing.T) {
 				return resp, nil
 			},
 		)
-		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, fgaClient.GetConfig().StoreId, test.RequestPath),
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, getStoreId(t, fgaClient), test.RequestPath),
 			func(req *http.Request) (*http.Response, error) {
 				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
 				if err != nil {
@@ -1876,7 +2326,7 @@ func TestOpenFgaClient(t *testing.T) {
 		}
 
 		if httpmock.GetTotalCallCount() != 4 {
-			t.Fatalf("OpenFgaClient.%v() - wanted %v calls to /check got %v", test.Name, 4, httpmock.GetTotalCallCount())
+			t.Fatalf("OpenFgaClient.%v() - wanted %v calls to /check, got %v", test.Name, 4, httpmock.GetTotalCallCount())
 		}
 
 		_, err = got.MarshalJSON()
@@ -1902,6 +2352,52 @@ func TestOpenFgaClient(t *testing.T) {
 			Execute()
 		if err == nil {
 			t.Fatalf("Expect error with invalid auth model id but there is none")
+		}
+
+		// invalid store ID should result in error
+		badStoreOptions := ClientListRelationsOptions{
+			AuthorizationModelId: openfga.PtrString(authModelId),
+			StoreId:              openfga.PtrString("INVALID"),
+		}
+		_, err = fgaClient.ListRelations(context.Background()).
+			Body(requestBody).
+			Options(badStoreOptions).
+			Execute()
+		if err == nil {
+			t.Fatalf("Expect error with invalid store id but there is none")
+		}
+
+		// store can be overridden
+		storeOverrideOptions := ClientListRelationsOptions{
+			StoreId: openfga.PtrString("7777HCE4YVKPQEKZQHT2R89MQV"),
+		}
+		httpmock.Reset()
+		httpmock.RegisterMatcherResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, *storeOverrideOptions.StoreId, test.RequestPath),
+			httpmock.BodyContainsString(`"relation":"can_delete"`),
+			func(req *http.Request) (*http.Response, error) {
+				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, openfga.CheckResponse{Allowed: openfga.PtrBool(false)})
+				if err != nil {
+					return httpmock.NewStringResponse(http.StatusInternalServerError, ""), nil
+				}
+				return resp, nil
+			},
+		)
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, *storeOverrideOptions.StoreId, test.RequestPath),
+			func(req *http.Request) (*http.Response, error) {
+				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
+				if err != nil {
+					return httpmock.NewStringResponse(http.StatusInternalServerError, ""), nil
+				}
+				return resp, nil
+			},
+		)
+
+		_, err = fgaClient.ListRelations(context.Background()).
+			Body(requestBody).
+			Options(storeOverrideOptions).
+			Execute()
+		if err != nil {
+			t.Fatalf("%v", err)
 		}
 
 	})
@@ -1986,7 +2482,7 @@ func TestOpenFgaClient(t *testing.T) {
 
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
-		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, fgaClient.GetConfig().StoreId, test.RequestPath),
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, getStoreId(t, fgaClient), test.RequestPath),
 			func(req *http.Request) (*http.Response, error) {
 				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
 				if err != nil {
@@ -2043,6 +2539,41 @@ func TestOpenFgaClient(t *testing.T) {
 		if err == nil {
 			t.Fatalf("Expect error with invalid auth model id but there is none")
 		}
+		// Invalid store id should result in error
+		badStoreOptions := ClientListUsersOptions{
+			StoreId: openfga.PtrString("INVALID"),
+		}
+		_, err = fgaClient.ListUsers(context.Background()).
+			Body(requestBody).
+			Options(badStoreOptions).
+			Execute()
+		if err == nil {
+			t.Fatalf("Expect error with invalid store model id but there is none")
+		}
+
+		// StoreId can be overridden
+		storeOverrideOptions := ClientListUsersOptions{
+			StoreId: openfga.PtrString("7777HCE4YVKPQEKZQHT2R89MQV"),
+		}
+		httpmock.Reset()
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, *storeOverrideOptions.StoreId, test.RequestPath),
+			func(req *http.Request) (*http.Response, error) {
+				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
+				if err != nil {
+					return httpmock.NewStringResponse(http.StatusInternalServerError, ""), nil
+				}
+				return resp, nil
+			},
+		)
+
+		_, err = fgaClient.ListUsers(context.Background()).
+			Body(requestBody).
+			Options(storeOverrideOptions).
+			Execute()
+
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
 	})
 
 	/* Assertions */
@@ -2067,7 +2598,7 @@ func TestOpenFgaClient(t *testing.T) {
 
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
-		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s/%s", fgaClient.GetConfig().ApiUrl, fgaClient.GetConfig().StoreId, test.RequestPath, modelId),
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s/%s", fgaClient.GetConfig().ApiUrl, getStoreId(t, fgaClient), test.RequestPath, modelId),
 			func(req *http.Request) (*http.Response, error) {
 				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
 				if err != nil {
@@ -2108,6 +2639,39 @@ func TestOpenFgaClient(t *testing.T) {
 		if err == nil {
 			t.Fatalf("Invalid auth model ID should result in error")
 		}
+
+		// Invalid store id should result in error
+		badStoreOptions := ClientReadAssertionsOptions{
+			StoreId: openfga.PtrString("INVALID"),
+		}
+		_, err = fgaClient.ReadAssertions(context.Background()).
+			Options(badStoreOptions).
+			Execute()
+		if err == nil {
+			t.Fatalf("Invalid store ID should result in error")
+		}
+
+		// store can be overriden
+		storeOverrideOptions := ClientReadAssertionsOptions{
+			AuthorizationModelId: openfga.PtrString(modelId),
+			StoreId:              openfga.PtrString("7777HCE4YVKPQEKZQHT2R89MQV"),
+		}
+		httpmock.Reset()
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s/%s", fgaClient.GetConfig().ApiUrl, *storeOverrideOptions.StoreId, test.RequestPath, modelId),
+			func(req *http.Request) (*http.Response, error) {
+				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
+				if err != nil {
+					return httpmock.NewStringResponse(http.StatusInternalServerError, ""), nil
+				}
+				return resp, nil
+			},
+		)
+		_, err = fgaClient.ReadAssertions(context.Background()).
+			Options(storeOverrideOptions).
+			Execute()
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
 	})
 
 	t.Run("WriteAssertions", func(t *testing.T) {
@@ -2134,7 +2698,7 @@ func TestOpenFgaClient(t *testing.T) {
 
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
-		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s/%s", fgaClient.GetConfig().ApiUrl, fgaClient.GetConfig().StoreId, test.RequestPath, modelId),
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s/%s", fgaClient.GetConfig().ApiUrl, getStoreId(t, fgaClient), test.RequestPath, modelId),
 			func(req *http.Request) (*http.Response, error) {
 				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, "")
 				if err != nil {
@@ -2166,5 +2730,47 @@ func TestOpenFgaClient(t *testing.T) {
 		if err == nil {
 			t.Fatalf("Invalid auth model id should result in error but there is none")
 		}
+
+		badStoreOptions := ClientWriteAssertionsOptions{
+			StoreId: openfga.PtrString("INVALID"),
+		}
+		_, err = fgaClient.WriteAssertions(context.Background()).
+			Body(requestBody).
+			Options(badStoreOptions).
+			Execute()
+		if err == nil {
+			t.Fatalf("Invalid store id should result in error but there is none")
+		}
+
+		// store can be overriden
+		storeOverrideOptions := ClientWriteAssertionsOptions{
+			AuthorizationModelId: openfga.PtrString(modelId),
+			StoreId:              openfga.PtrString("7777HCE4YVKPQEKZQHT2R89MQV"),
+		}
+		httpmock.Reset()
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s/%s", fgaClient.GetConfig().ApiUrl, *storeOverrideOptions.StoreId, test.RequestPath, modelId),
+			func(req *http.Request) (*http.Response, error) {
+				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, "")
+				if err != nil {
+					return httpmock.NewStringResponse(http.StatusInternalServerError, ""), nil
+				}
+				return resp, nil
+			},
+		)
+		_, err = fgaClient.WriteAssertions(context.Background()).
+			Body(requestBody).
+			Options(storeOverrideOptions).
+			Execute()
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
 	})
+}
+
+func getStoreId(t *testing.T, fgaClient *OpenFgaClient) string {
+	storeId, err := fgaClient.GetStoreId()
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	return storeId
 }

--- a/client/errors.go
+++ b/client/errors.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/configuration.go
+++ b/configuration.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community
@@ -16,7 +16,6 @@ import (
 	"net/http"
 
 	"github.com/openfga/go-sdk/credentials"
-	"github.com/openfga/go-sdk/internal/utils"
 )
 
 const (
@@ -40,7 +39,6 @@ type Configuration struct {
 	// Deprecated: use ApiUrl instead of ApiScheme and ApiHost
 	ApiHost        string                   `json:"api_host,omitempty"`
 	ApiUrl         string                   `json:"api_url,omitempty"`
-	StoreId        string                   `json:"store_id,omitempty"`
 	Credentials    *credentials.Credentials `json:"credentials,omitempty"`
 	DefaultHeaders map[string]string        `json:"default_headers,omitempty"`
 	UserAgent      string                   `json:"user_agent,omitempty"`
@@ -77,7 +75,6 @@ func NewConfiguration(config Configuration) (*Configuration, error) {
 
 	cfg := &Configuration{
 		ApiUrl:         apiUrl,
-		StoreId:        config.StoreId,
 		Credentials:    config.Credentials,
 		DefaultHeaders: config.DefaultHeaders,
 		UserAgent:      config.UserAgent,
@@ -125,10 +122,6 @@ func (c *Configuration) ValidateConfig() error {
 
 	if c.RetryParams != nil && c.RetryParams.MaxRetry > 15 {
 		return reportError("Configuration.RetryParams.MaxRetry exceeds maximum allowed limit of 15")
-	}
-
-	if c.StoreId != "" && !internalutils.IsWellFormedUlidString(c.StoreId) {
-		return reportError("Configuration.StoreId is not a valid ulid")
 	}
 
 	return nil

--- a/docs/ListUsersRequest.md
+++ b/docs/ListUsersRequest.md
@@ -7,7 +7,7 @@ Name | Type | Description | Notes
 **AuthorizationModelId** | Pointer to **string** |  | [optional] 
 **Object** | [**FgaObject**](FgaObject.md) |  | 
 **Relation** | **string** |  | 
-**UserFilters** | [**[]UserTypeFilter**](UserTypeFilter.md) |  | 
+**UserFilters** | [**[]UserTypeFilter**](UserTypeFilter.md) | The type of results returned. Only accepts exactly one value. | 
 **ContextualTuples** | Pointer to [**[]TupleKey**](TupleKey.md) |  | [optional] 
 **Context** | Pointer to **map[string]interface{}** | Additional request context that will be used to evaluate any ABAC conditions encountered in the query evaluation. | [optional] 
 

--- a/docs/OpenFgaApi.md
+++ b/docs/OpenFgaApi.md
@@ -11,7 +11,7 @@ Method | HTTP request | Description
 [**GetStore**](OpenFgaApi.md#GetStore) | **Get** /stores/{store_id} | Get a store
 [**ListObjects**](OpenFgaApi.md#ListObjects) | **Post** /stores/{store_id}/list-objects | List all objects of the given type that the user has a relation with
 [**ListStores**](OpenFgaApi.md#ListStores) | **Get** /stores | List all stores
-[**ListUsers**](OpenFgaApi.md#ListUsers) | **Post** /stores/{store_id}/list-users | List all users of the given type that the object has a relation with
+[**ListUsers**](OpenFgaApi.md#ListUsers) | **Post** /stores/{store_id}/list-users | [EXPERIMENTAL] List the users matching the provided filter who have a certain relation to a particular type.
 [**Read**](OpenFgaApi.md#Read) | **Post** /stores/{store_id}/read | Get tuples from the store that matches a query, without following userset rewrite rules
 [**ReadAssertions**](OpenFgaApi.md#ReadAssertions) | **Get** /stores/{store_id}/assertions/{authorization_model_id} | Read assertions for an authorization model ID
 [**ReadAuthorizationModel**](OpenFgaApi.md#ReadAuthorizationModel) | **Get** /stores/{store_id}/authorization-models/{id} | Return a particular version of an authorization model
@@ -666,7 +666,9 @@ No authorization required
 
 > ListUsersResponse ListUsers(ctx).Body(body).Execute()
 
-List all users of the given type that the object has a relation with
+[EXPERIMENTAL] List the users matching the provided filter who have a certain relation to a particular type.
+
+
 
 ### Example
 
@@ -682,7 +684,7 @@ import (
 
 func main() {
     
-    body := *openapiclient.NewListUsersRequest(*openapiclient.NewFgaObject("document", "Id_example"), "reader", []openapiclient.UserTypeFilter{*openapiclient.NewUserTypeFilter("group")}) // ListUsersRequest | 
+    body := *openapiclient.NewListUsersRequest(*openapiclient.NewFgaObject("document", "0bcdf6fa-a6aa-4730-a8eb-9cf172ff16d9"), "reader", []openapiclient.UserTypeFilter{*openapiclient.NewUserTypeFilter("group")}) // ListUsersRequest | 
 
     configuration, err := openfga.NewConfiguration(openfga.Configuration{
         ApiUrl:         os.Getenv("FGA_API_URL"), // required, e.g. https://api.fga.example

--- a/docs/UnauthenticatedResponse.md
+++ b/docs/UnauthenticatedResponse.md
@@ -1,0 +1,82 @@
+# UnauthenticatedResponse
+
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**Code** | Pointer to [**ErrorCode**](ErrorCode.md) |  | [optional] [default to NO_ERROR]
+**Message** | Pointer to **string** |  | [optional] 
+
+## Methods
+
+### NewUnauthenticatedResponse
+
+`func NewUnauthenticatedResponse() *UnauthenticatedResponse`
+
+NewUnauthenticatedResponse instantiates a new UnauthenticatedResponse object
+This constructor will assign default values to properties that have it defined,
+and makes sure properties required by API are set, but the set of arguments
+will change when the set of required properties is changed
+
+### NewUnauthenticatedResponseWithDefaults
+
+`func NewUnauthenticatedResponseWithDefaults() *UnauthenticatedResponse`
+
+NewUnauthenticatedResponseWithDefaults instantiates a new UnauthenticatedResponse object
+This constructor will only assign default values to properties that have it defined,
+but it doesn't guarantee that properties required by API are set
+
+### GetCode
+
+`func (o *UnauthenticatedResponse) GetCode() ErrorCode`
+
+GetCode returns the Code field if non-nil, zero value otherwise.
+
+### GetCodeOk
+
+`func (o *UnauthenticatedResponse) GetCodeOk() (*ErrorCode, bool)`
+
+GetCodeOk returns a tuple with the Code field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetCode
+
+`func (o *UnauthenticatedResponse) SetCode(v ErrorCode)`
+
+SetCode sets Code field to given value.
+
+### HasCode
+
+`func (o *UnauthenticatedResponse) HasCode() bool`
+
+HasCode returns a boolean if a field has been set.
+
+### GetMessage
+
+`func (o *UnauthenticatedResponse) GetMessage() string`
+
+GetMessage returns the Message field if non-nil, zero value otherwise.
+
+### GetMessageOk
+
+`func (o *UnauthenticatedResponse) GetMessageOk() (*string, bool)`
+
+GetMessageOk returns a tuple with the Message field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetMessage
+
+`func (o *UnauthenticatedResponse) SetMessage(v string)`
+
+SetMessage sets Message field to given value.
+
+### HasMessage
+
+`func (o *UnauthenticatedResponse) HasMessage() bool`
+
+HasMessage returns a boolean if a field has been set.
+
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+

--- a/internal/utils/randomtime.go
+++ b/internal/utils/randomtime.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/internal/utils/ulid.go
+++ b/internal/utils/ulid.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/internal/utils/ulid_test.go
+++ b/internal/utils/ulid_test.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_aborted_message_response.go
+++ b/model_aborted_message_response.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_any.go
+++ b/model_any.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_assertion.go
+++ b/model_assertion.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_assertion_tuple_key.go
+++ b/model_assertion_tuple_key.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_authorization_model.go
+++ b/model_authorization_model.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_check_request.go
+++ b/model_check_request.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_check_request_tuple_key.go
+++ b/model_check_request_tuple_key.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_check_response.go
+++ b/model_check_response.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_computed.go
+++ b/model_computed.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_condition.go
+++ b/model_condition.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_condition_metadata.go
+++ b/model_condition_metadata.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_condition_param_type_ref.go
+++ b/model_condition_param_type_ref.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_contextual_tuple_keys.go
+++ b/model_contextual_tuple_keys.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_create_store_request.go
+++ b/model_create_store_request.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_create_store_response.go
+++ b/model_create_store_response.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_difference.go
+++ b/model_difference.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_error_code.go
+++ b/model_error_code.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_expand_request.go
+++ b/model_expand_request.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_expand_request_tuple_key.go
+++ b/model_expand_request_tuple_key.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_expand_response.go
+++ b/model_expand_response.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_fga_object.go
+++ b/model_fga_object.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_get_store_response.go
+++ b/model_get_store_response.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_internal_error_code.go
+++ b/model_internal_error_code.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_internal_error_message_response.go
+++ b/model_internal_error_message_response.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_leaf.go
+++ b/model_leaf.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_list_objects_request.go
+++ b/model_list_objects_request.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_list_objects_response.go
+++ b/model_list_objects_response.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_list_stores_response.go
+++ b/model_list_stores_response.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_list_users_request.go
+++ b/model_list_users_request.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community
@@ -20,11 +20,12 @@ import (
 
 // ListUsersRequest struct for ListUsersRequest
 type ListUsersRequest struct {
-	AuthorizationModelId *string          `json:"authorization_model_id,omitempty"yaml:"authorization_model_id,omitempty"`
-	Object               FgaObject        `json:"object"yaml:"object"`
-	Relation             string           `json:"relation"yaml:"relation"`
-	UserFilters          []UserTypeFilter `json:"user_filters"yaml:"user_filters"`
-	ContextualTuples     *[]TupleKey      `json:"contextual_tuples,omitempty"yaml:"contextual_tuples,omitempty"`
+	AuthorizationModelId *string   `json:"authorization_model_id,omitempty"yaml:"authorization_model_id,omitempty"`
+	Object               FgaObject `json:"object"yaml:"object"`
+	Relation             string    `json:"relation"yaml:"relation"`
+	// The type of results returned. Only accepts exactly one value.
+	UserFilters      []UserTypeFilter `json:"user_filters"yaml:"user_filters"`
+	ContextualTuples *[]TupleKey      `json:"contextual_tuples,omitempty"yaml:"contextual_tuples,omitempty"`
 	// Additional request context that will be used to evaluate any ABAC conditions encountered in the query evaluation.
 	Context *map[string]interface{} `json:"context,omitempty"yaml:"context,omitempty"`
 }

--- a/model_list_users_response.go
+++ b/model_list_users_response.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_metadata.go
+++ b/model_metadata.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_node.go
+++ b/model_node.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_nodes.go
+++ b/model_nodes.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_not_found_error_code.go
+++ b/model_not_found_error_code.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_null_value.go
+++ b/model_null_value.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_object_or_userset.go
+++ b/model_object_or_userset.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_object_relation.go
+++ b/model_object_relation.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_path_unknown_error_message_response.go
+++ b/model_path_unknown_error_message_response.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_read_assertions_response.go
+++ b/model_read_assertions_response.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_read_authorization_model_response.go
+++ b/model_read_authorization_model_response.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_read_authorization_models_response.go
+++ b/model_read_authorization_models_response.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_read_changes_response.go
+++ b/model_read_changes_response.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_read_request.go
+++ b/model_read_request.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_read_request_tuple_key.go
+++ b/model_read_request_tuple_key.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_read_response.go
+++ b/model_read_response.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_relation_metadata.go
+++ b/model_relation_metadata.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_relation_reference.go
+++ b/model_relation_reference.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_relationship_condition.go
+++ b/model_relationship_condition.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_source_info.go
+++ b/model_source_info.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_store.go
+++ b/model_store.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_tuple.go
+++ b/model_tuple.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_tuple_change.go
+++ b/model_tuple_change.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_tuple_key.go
+++ b/model_tuple_key.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_tuple_key_without_condition.go
+++ b/model_tuple_key_without_condition.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_tuple_operation.go
+++ b/model_tuple_operation.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_tuple_to_userset.go
+++ b/model_tuple_to_userset.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_type_definition.go
+++ b/model_type_definition.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_type_name.go
+++ b/model_type_name.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_typed_wildcard.go
+++ b/model_typed_wildcard.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community
@@ -18,7 +18,7 @@ import (
 	"encoding/json"
 )
 
-// TypedWildcard struct for TypedWildcard
+// TypedWildcard Type bound public access.  Normally represented using the `<type>:*` syntax  `employee:*` represents every object of type `employee`, including those not currently present in the system  See https://openfga.dev/docs/concepts#what-is-type-bound-public-access
 type TypedWildcard struct {
 	Type string `json:"type"yaml:"type"`
 }

--- a/model_unauthenticated_response.go
+++ b/model_unauthenticated_response.go
@@ -18,34 +18,37 @@ import (
 	"encoding/json"
 )
 
-// Status struct for Status
-type Status struct {
-	Code    *int32  `json:"code,omitempty"yaml:"code,omitempty"`
-	Message *string `json:"message,omitempty"yaml:"message,omitempty"`
-	Details *[]Any  `json:"details,omitempty"yaml:"details,omitempty"`
+// UnauthenticatedResponse struct for UnauthenticatedResponse
+type UnauthenticatedResponse struct {
+	Code    *ErrorCode `json:"code,omitempty"yaml:"code,omitempty"`
+	Message *string    `json:"message,omitempty"yaml:"message,omitempty"`
 }
 
-// NewStatus instantiates a new Status object
+// NewUnauthenticatedResponse instantiates a new UnauthenticatedResponse object
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewStatus() *Status {
-	this := Status{}
+func NewUnauthenticatedResponse() *UnauthenticatedResponse {
+	this := UnauthenticatedResponse{}
+	var code ErrorCode = NO_ERROR
+	this.Code = &code
 	return &this
 }
 
-// NewStatusWithDefaults instantiates a new Status object
+// NewUnauthenticatedResponseWithDefaults instantiates a new UnauthenticatedResponse object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
-func NewStatusWithDefaults() *Status {
-	this := Status{}
+func NewUnauthenticatedResponseWithDefaults() *UnauthenticatedResponse {
+	this := UnauthenticatedResponse{}
+	var code ErrorCode = NO_ERROR
+	this.Code = &code
 	return &this
 }
 
 // GetCode returns the Code field value if set, zero value otherwise.
-func (o *Status) GetCode() int32 {
+func (o *UnauthenticatedResponse) GetCode() ErrorCode {
 	if o == nil || o.Code == nil {
-		var ret int32
+		var ret ErrorCode
 		return ret
 	}
 	return *o.Code
@@ -53,7 +56,7 @@ func (o *Status) GetCode() int32 {
 
 // GetCodeOk returns a tuple with the Code field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Status) GetCodeOk() (*int32, bool) {
+func (o *UnauthenticatedResponse) GetCodeOk() (*ErrorCode, bool) {
 	if o == nil || o.Code == nil {
 		return nil, false
 	}
@@ -61,7 +64,7 @@ func (o *Status) GetCodeOk() (*int32, bool) {
 }
 
 // HasCode returns a boolean if a field has been set.
-func (o *Status) HasCode() bool {
+func (o *UnauthenticatedResponse) HasCode() bool {
 	if o != nil && o.Code != nil {
 		return true
 	}
@@ -69,13 +72,13 @@ func (o *Status) HasCode() bool {
 	return false
 }
 
-// SetCode gets a reference to the given int32 and assigns it to the Code field.
-func (o *Status) SetCode(v int32) {
+// SetCode gets a reference to the given ErrorCode and assigns it to the Code field.
+func (o *UnauthenticatedResponse) SetCode(v ErrorCode) {
 	o.Code = &v
 }
 
 // GetMessage returns the Message field value if set, zero value otherwise.
-func (o *Status) GetMessage() string {
+func (o *UnauthenticatedResponse) GetMessage() string {
 	if o == nil || o.Message == nil {
 		var ret string
 		return ret
@@ -85,7 +88,7 @@ func (o *Status) GetMessage() string {
 
 // GetMessageOk returns a tuple with the Message field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Status) GetMessageOk() (*string, bool) {
+func (o *UnauthenticatedResponse) GetMessageOk() (*string, bool) {
 	if o == nil || o.Message == nil {
 		return nil, false
 	}
@@ -93,7 +96,7 @@ func (o *Status) GetMessageOk() (*string, bool) {
 }
 
 // HasMessage returns a boolean if a field has been set.
-func (o *Status) HasMessage() bool {
+func (o *UnauthenticatedResponse) HasMessage() bool {
 	if o != nil && o.Message != nil {
 		return true
 	}
@@ -102,52 +105,17 @@ func (o *Status) HasMessage() bool {
 }
 
 // SetMessage gets a reference to the given string and assigns it to the Message field.
-func (o *Status) SetMessage(v string) {
+func (o *UnauthenticatedResponse) SetMessage(v string) {
 	o.Message = &v
 }
 
-// GetDetails returns the Details field value if set, zero value otherwise.
-func (o *Status) GetDetails() []Any {
-	if o == nil || o.Details == nil {
-		var ret []Any
-		return ret
-	}
-	return *o.Details
-}
-
-// GetDetailsOk returns a tuple with the Details field value if set, nil otherwise
-// and a boolean to check if the value has been set.
-func (o *Status) GetDetailsOk() (*[]Any, bool) {
-	if o == nil || o.Details == nil {
-		return nil, false
-	}
-	return o.Details, true
-}
-
-// HasDetails returns a boolean if a field has been set.
-func (o *Status) HasDetails() bool {
-	if o != nil && o.Details != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetDetails gets a reference to the given []Any and assigns it to the Details field.
-func (o *Status) SetDetails(v []Any) {
-	o.Details = &v
-}
-
-func (o Status) MarshalJSON() ([]byte, error) {
+func (o UnauthenticatedResponse) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
 	if o.Code != nil {
 		toSerialize["code"] = o.Code
 	}
 	if o.Message != nil {
 		toSerialize["message"] = o.Message
-	}
-	if o.Details != nil {
-		toSerialize["details"] = o.Details
 	}
 	var b bytes.Buffer
 	enc := json.NewEncoder(&b)
@@ -159,38 +127,38 @@ func (o Status) MarshalJSON() ([]byte, error) {
 	return b.Bytes(), nil
 }
 
-type NullableStatus struct {
-	value *Status
+type NullableUnauthenticatedResponse struct {
+	value *UnauthenticatedResponse
 	isSet bool
 }
 
-func (v NullableStatus) Get() *Status {
+func (v NullableUnauthenticatedResponse) Get() *UnauthenticatedResponse {
 	return v.value
 }
 
-func (v *NullableStatus) Set(val *Status) {
+func (v *NullableUnauthenticatedResponse) Set(val *UnauthenticatedResponse) {
 	v.value = val
 	v.isSet = true
 }
 
-func (v NullableStatus) IsSet() bool {
+func (v NullableUnauthenticatedResponse) IsSet() bool {
 	return v.isSet
 }
 
-func (v *NullableStatus) Unset() {
+func (v *NullableUnauthenticatedResponse) Unset() {
 	v.value = nil
 	v.isSet = false
 }
 
-func NewNullableStatus(val *Status) *NullableStatus {
-	return &NullableStatus{value: val, isSet: true}
+func NewNullableUnauthenticatedResponse(val *UnauthenticatedResponse) *NullableUnauthenticatedResponse {
+	return &NullableUnauthenticatedResponse{value: val, isSet: true}
 }
 
-func (v NullableStatus) MarshalJSON() ([]byte, error) {
+func (v NullableUnauthenticatedResponse) MarshalJSON() ([]byte, error) {
 	return json.Marshal(v.value)
 }
 
-func (v *NullableStatus) UnmarshalJSON(src []byte) error {
+func (v *NullableUnauthenticatedResponse) UnmarshalJSON(src []byte) error {
 	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/model_unprocessable_content_error_code.go
+++ b/model_unprocessable_content_error_code.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_unprocessable_content_message_response.go
+++ b/model_unprocessable_content_message_response.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_user.go
+++ b/model_user.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community
@@ -18,7 +18,7 @@ import (
 	"encoding/json"
 )
 
-// User struct for User
+// User User.  Represents any possible value for a user (subject or principal). Can be a: - Specific user object e.g.: 'user:will', 'folder:marketing', 'org:contoso', ...) - Specific userset (e.g. 'group:engineering#member') - Public-typed wildcard (e.g. 'user:*')  See https://openfga.dev/docs/concepts#what-is-a-user
 type User struct {
 	Object   *FgaObject     `json:"object,omitempty"yaml:"object,omitempty"`
 	Userset  *UsersetUser   `json:"userset,omitempty"yaml:"userset,omitempty"`

--- a/model_user_type_filter.go
+++ b/model_user_type_filter.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_users.go
+++ b/model_users.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_userset.go
+++ b/model_userset.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_userset_tree.go
+++ b/model_userset_tree.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_userset_tree_difference.go
+++ b/model_userset_tree_difference.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_userset_tree_tuple_to_userset.go
+++ b/model_userset_tree_tuple_to_userset.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_userset_user.go
+++ b/model_userset_user.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community
@@ -18,7 +18,7 @@ import (
 	"encoding/json"
 )
 
-// UsersetUser struct for UsersetUser
+// UsersetUser Userset.  A set or group of users, represented in the `<type>:<id>#<relation>` format  `group:fga#member` represents all members of group FGA, not to be confused by `group:fga` which represents the group itself as a specific object.  See: https://openfga.dev/docs/modeling/building-blocks/usersets#what-is-a-userset
 type UsersetUser struct {
 	Type     string `json:"type"yaml:"type"`
 	Id       string `json:"id"yaml:"id"`

--- a/model_usersets.go
+++ b/model_usersets.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_validation_error_message_response.go
+++ b/model_validation_error_message_response.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_write_assertions_request.go
+++ b/model_write_assertions_request.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_write_authorization_model_request.go
+++ b/model_write_authorization_model_request.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_write_authorization_model_response.go
+++ b/model_write_authorization_model_response.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_write_request.go
+++ b/model_write_request.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_write_request_deletes.go
+++ b/model_write_request_deletes.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/model_write_request_writes.go
+++ b/model_write_request_writes.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/response.go
+++ b/response.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community

--- a/utils.go
+++ b/utils.go
@@ -1,7 +1,7 @@
 /**
  * Go SDK for OpenFGA
  *
- * API version: 0.1
+ * API version: 1.x
  * Website: https://openfga.dev
  * Documentation: https://openfga.dev/docs
  * Support: https://openfga.dev/community


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

Removes `StoreId` from `api_open_fga.go` configuration, and enables per-request override of the `StoreId`. 

## Description
<!-- Provide a detailed description of the changes -->

⚠️ Breaking change ⚠️

Removes the `StoreId` from the API client, and instead accept the `StoreId` as a parameter. As discussed in #118, this allows for the removal of the custom patch during SDK generation. 

**If using api_open_fga.go directly, you will now need to pass the StoreId parameter.**

This change also enables per-request override of the `StoreId`, via the associated request's options. 

## References
* https://github.com/openfga/sdk-generator/issues/118
* https://github.com/openfga/sdk-generator/pull/359
* Generated from https://github.com/openfga/sdk-generator/pull/364

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
