### PR TITLE
fix: ListUsers readme typos

### DIFF
--- a/example/example1/example1.go
+++ b/example/example1/example1.go
@@ -3,10 +3,11 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
+
 	openfga "github.com/openfga/go-sdk"
 	"github.com/openfga/go-sdk/client"
 	"github.com/openfga/go-sdk/credentials"
-	"os"
 )
 
 func mainInner() error {
@@ -265,11 +266,11 @@ func mainInner() error {
 	fmt.Println("Listing user who have access to object")
 	listUsersResponse, err := fgaClient.ListUsers(ctx).Body(client.ClientListUsersRequest{
 		Relation: "viewer",
-		Object: openfga.Object{
+		Object: openfga.FgaObject{
 			Type: "document",
 			Id:   "roadmap",
 		},
-		UserFilters: []openfga.ListUsersFilter{{
+		UserFilters: []openfga.UserTypeFilter{{
 			Type: "user",
 		}},
 	}).Execute()


### PR DESCRIPTION
## Description
While testing ListUsers for internal usage, I noticed a couple small typos in the README.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
