### PR TITLE
release: v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v0.5.0
+
+### [0.5.0](https://github.com/openfga/go-sdk/compare/v0.4.0...v0.5.0) (2024-06-14)
+- fix: correctly set HTTPClient - thanks @wonyx
+- chore!: remove excluded users from ListUsers response
+
+BREAKING CHANGE:
+
+This version removes the `ExcludedUsers` field from the `ListUsersResponse` and `ClientListUsersResponse` structs,
+for more details see the [associated API change](https://github.com/openfga/api/pull/171).
+
 ## v0.4.0
 
 ### [0.4.0](https://github.com/openfga/go-sdk/compare/v0.3.7...v0.4.0) (2024-05-30)

--- a/configuration.go
+++ b/configuration.go
@@ -19,9 +19,9 @@ import (
 )
 
 const (
-	SdkVersion = "0.4.0"
+	SdkVersion = "0.5.0"
 
-	defaultUserAgent = "openfga-sdk go/0.4.0"
+	defaultUserAgent = "openfga-sdk go/0.5.0"
 )
 
 // RetryParams configures configuration for retry in case of HTTP too many request

--- a/example/example1/go.mod
+++ b/example/example1/go.mod
@@ -2,9 +2,9 @@ module example1
 
 go 1.22.2
 
-require github.com/openfga/go-sdk v0.4.0
+require github.com/openfga/go-sdk v0.5.0
 
 require golang.org/x/sync v0.7.0 // indirect
 
 // To reference local build, uncomment below and run `go mod tidy`
-replace github.com/openfga/go-sdk v0.4.0 => ../../
+replace github.com/openfga/go-sdk v0.5.0 => ../../


### PR DESCRIPTION
## Description

```
- fix: correctly set HTTPClient
- chore!: remove excluded users from ListUsers response

BREAKING CHANGE:

This version removes the `ExcludedUsers` field from the `ListUsersResponse` and `ClientListUsersResponse` structs,
for more details see the [associated API change](https://github.com/openfga/api/pull/171).
```

## References


## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
