### PR TITLE
chore: fix out-dated document of ClientTupleKey

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,7 +507,7 @@ By default, write runs in a transaction mode where any invalid operation (deleti
 
 ```golang
 body := ClientWriteRequest{
-    Writes: &[]ClientTupleKey{ {
+    Writes: []ClientTupleKey{ {
         User:     "user:81684243-9356-4421-8fbf-a4f8d36aa31b",
         Relation: "viewer",
         Object:   "document:roadmap",
@@ -516,7 +516,7 @@ body := ClientWriteRequest{
         Relation: "viewer",
         Object:   "document:budget",
     } },
-    Deletes: &[]ClientTupleKeyWithoutCondition{ {
+    Deletes: []ClientTupleKeyWithoutCondition{ {
         User:     "user:81684243-9356-4421-8fbf-a4f8d36aa31b",
         Relation: "writer",
         Object:   "document:roadmap",
@@ -540,7 +540,7 @@ The SDK will split the writes into separate chunks and send them in separate req
 
 ```golang
 body := ClientWriteRequest{
-    Writes: &[]ClientTupleKey{ {
+    Writes: []ClientTupleKey{ {
         User:     "user:81684243-9356-4421-8fbf-a4f8d36aa31b",
         Relation: "viewer",
         Object:   "document:roadmap",
@@ -549,7 +549,7 @@ body := ClientWriteRequest{
         Relation: "viewer",
         Object:   "document:budget",
     } },
-	  Deletes: &[]ClientTupleKeyWithoutCondition{ {
+	  Deletes: []ClientTupleKeyWithoutCondition{ {
       User:     "user:81684243-9356-4421-8fbf-a4f8d36aa31b",
       Relation: "writer",
       Object:   "document:roadmap",
@@ -601,7 +601,7 @@ body := ClientCheckRequest{
     User:     "user:81684243-9356-4421-8fbf-a4f8d36aa31b",
     Relation: "viewer",
     Object:   "document:roadmap",
-    ContextualTuples: &[]ClientTupleKey{ {
+    ContextualTuples: []ClientTupleKey{ {
         User:     "user:81684243-9356-4421-8fbf-a4f8d36aa31b",
         Relation: "editor",
         Object:   "document:roadmap",
@@ -639,7 +639,7 @@ body := ClientBatchCheckBody{ {
     User:     "user:81684243-9356-4421-8fbf-a4f8d36aa31b",
     Relation: "viewer",
     Object:   "document:roadmap",
-    ContextualTuples: &[]ClientTupleKey{ {
+    ContextualTuples: []ClientTupleKey{ {
         User:     "user:81684243-9356-4421-8fbf-a4f8d36aa31b",
         Relation: "editor",
         Object:   "document:roadmap",
@@ -648,7 +648,7 @@ body := ClientBatchCheckBody{ {
     User:     "user:81684243-9356-4421-8fbf-a4f8d36aa31b",
     Relation: "admin",
     Object:   "document:roadmap",
-    ContextualTuples: &[]ClientTupleKey{ {
+    ContextualTuples: []ClientTupleKey{ {
         User:     "user:81684243-9356-4421-8fbf-a4f8d36aa31b",
         Relation: "editor",
         Object:   "document:roadmap",
@@ -752,7 +752,7 @@ body := ClientListObjectsRequest{
     User:     "user:81684243-9356-4421-8fbf-a4f8d36aa31b",
     Relation: "can_read",
     Type:     "document",
-    ContextualTuples: &[]ClientTupleKey{ {
+    ContextualTuples: []ClientTupleKey{ {
         User:     "user:81684243-9356-4421-8fbf-a4f8d36aa31b",
         Relation: "editor",
         Object:   "folder:product",
@@ -787,7 +787,7 @@ body := ClientListRelationsRequest{
     User:      "user:81684243-9356-4421-8fbf-a4f8d36aa31b",
     Object:    "document:roadmap",
     Relations: []string{"can_view", "can_edit", "can_delete", "can_rename"},
-    ContextualTuples: &[]ClientTupleKey{ {
+    ContextualTuples: []ClientTupleKey{ {
         User:     "user:81684243-9356-4421-8fbf-a4f8d36aa31b",
         Relation: "editor",
         Object:   "document:roadmap",


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->
ClientTupleKey type had changed, but readme file is still &[]ClientTupleKey

## Description
<!-- Provide a detailed description of the changes -->

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [√] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [√] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [√] The correct base branch is being used, if not `main`
- [√] I have added tests to validate that the change in functionality is working as expected
