### PR TITLE
release: v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## v0.6.0
+
+### [0.6.0](https://github.com/openfga/go-sdk/compare/v0.5.0...v0.6.0) (2024-08-29)
+
+- feat: support OpenTelemetry metrics reporting (#115)
+- feat!: support for sending the consistency parameter to the read, check, list users, list objects, and expand endpoints (#117)
+- chore(docs): update stale README (#113) - thanks @Code2Life
+
+BREAKING CHANGE:
+
+When the generator converts enums in the open API definition, by default it removes the type prefix. For example, `TYPE_NAME_UNSPECIFIED` is converted to a const named `UNSPECIFIED`. This leads to potential collisions with other enums, and as the consistency type is a new enum, we finally got a collision (was just a matter of time).
+
+The fix for this is to specify `"enumClassPrefix": true` in the generation config. This will then include the class name on the const name, which resoles collision issues. This means any enum value, such as `INT` now becomes `TYPENAME_INT`. The main impact of this is the `TypeName` consts and error codes. The fix is to add the class name prefix as discussed above.
+
 ## v0.5.0
 
 ### [0.5.0](https://github.com/openfga/go-sdk/compare/v0.4.0...v0.5.0) (2024-06-14)

--- a/configuration.go
+++ b/configuration.go
@@ -20,9 +20,9 @@ import (
 )
 
 const (
-	SdkVersion = "0.5.0"
+	SdkVersion = "0.6.0"
 
-	defaultUserAgent = "openfga-sdk go/0.5.0"
+	defaultUserAgent = "openfga-sdk go/0.6.0"
 )
 
 // RetryParams configures configuration for retry in case of HTTP too many request

--- a/example/example1/go.mod
+++ b/example/example1/go.mod
@@ -2,9 +2,9 @@ module example1
 
 go 1.22.2
 
-require github.com/openfga/go-sdk v0.5.0
+require github.com/openfga/go-sdk v0.6.0
 
 require golang.org/x/sync v0.8.0 // indirect
 
 // To reference local build, uncomment below and run `go mod tidy`
-replace github.com/openfga/go-sdk v0.5.0 => ../../
+replace github.com/openfga/go-sdk v0.6.0 => ../../

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -49,7 +49,7 @@ var (
 func Configure(configuration *Configuration) (*Telemetry, error) {
 	return &Telemetry{
 		Metrics: &Metrics{
-			Meter:         otel.Meter("openfga-sdk/0.5.0"),
+			Meter:         otel.Meter("openfga-sdk/0.6.0"),
 			Counters:      make(map[string]metric.Int64Counter),
 			Histograms:    make(map[string]metric.Float64Histogram),
 			Configuration: configuration.Metrics,


### PR DESCRIPTION
## v0.6.0

- feat: support OpenTelemetry metrics reporting
- feat!: support for sending the consistency parameter to the read, check, list users, list objects, and expand endpoints.

BREAKING CHANGE:

When the generator converts enums in the open API definition, by default it removes the type prefix. For example, `TYPE_NAME_UNSPECIFIED` is converted to a const named `UNSPECIFIED`. This leads to potential collisions with other enums, and as the consistency type is a new enum, we finally got a collision (was just a matter of time).

The fix for this is to specify `"enumClassPrefix": true` in the generation config. This will then include the class name on the const name, which resoles collision issues. This means any enum value, such as `INT` now becomes `TYPENAME_INT`. The main impact of this is the `TypeName` consts and error codes. The fix is to add the class name prefix as discussed above.