### PR TITLE
release: v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.6.1
+
+### [0.6.1](https://github.com/openfga/go-sdk/compare/v0.6.0...v0.6.1) (2024-09-23)
+
+- refactor(OpenTelemetry): move configuration API into public package namespace (#122)
+- docs(OpenTelemetry): initial documentation and example (#123)
+
 ## v0.6.0
 
 ### [0.6.0](https://github.com/openfga/go-sdk/compare/v0.5.0...v0.6.0) (2024-08-29)

--- a/README.md
+++ b/README.md
@@ -1038,7 +1038,7 @@ Class | Method | HTTP request | Description
 
 ### OpenTelemetry
 
-This SDK supports producing metrics that can be consumed as part of an [OpenTelemetry](https://opentelemetry.io/) setup. For more information, please see [the documentation](https://github.com/openfga/java-sdk/blob/main/docs/OpenTelemetry.md)
+This SDK supports producing metrics that can be consumed as part of an [OpenTelemetry](https://opentelemetry.io/) setup. For more information, please see [the documentation](https://github.com/openfga/go-sdk/blob/main/docs/OpenTelemetry.md)
 
 ## Contributing
 

--- a/example/example1/go.mod
+++ b/example/example1/go.mod
@@ -2,9 +2,9 @@ module example1
 
 go 1.22.2
 
-require github.com/openfga/go-sdk v0.6.0
+require github.com/openfga/go-sdk v0.6.1
 
 require golang.org/x/sync v0.8.0 // indirect
 
 // To reference local build, uncomment below and run `go mod tidy`
-replace github.com/openfga/go-sdk v0.6.0 => ../../
+replace github.com/openfga/go-sdk v0.6.1 => ../../


### PR DESCRIPTION
### [0.6.1](https://github.com/openfga/go-sdk/compare/v0.6.0...v0.6.1) (2024-09-23)

- refactor(OpenTelemetry): move configuration API into public package namespace (#122)
- docs(OpenTelemetry): initial documentation and example (#123)