### PR TITLE
fix: fix data race of TelemetryInstances variable

### DIFF
--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -2,6 +2,7 @@ package telemetry
 
 import (
 	"context"
+	"sync"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/metric"
@@ -42,6 +43,9 @@ type QueryDurationMetricParameters struct {
 type TelemetryContextKey struct{}
 
 var (
+	telemetryInstancesLock sync.Mutex
+	// Warning: do not use directly, it may cause data race.
+	// Deprecated: this map will be renamed to telemetryInstances.
 	TelemetryInstances map[*Configuration]*Telemetry
 	TelemetryContext   TelemetryContextKey
 )
@@ -64,6 +68,9 @@ func Get(factory TelemetryFactoryParameters) *Telemetry {
 	if configuration == nil {
 		configuration = DefaultTelemetryConfiguration()
 	}
+
+	telemetryInstancesLock.Lock()
+	defer telemetryInstancesLock.Unlock()
 
 	if TelemetryInstances == nil {
 		TelemetryInstances = make(map[*Configuration]*Telemetry)

--- a/telemetry/telemetry_test.go
+++ b/telemetry/telemetry_test.go
@@ -3,6 +3,7 @@ package telemetry
 import (
 	"context"
 	"net/http"
+	"sync"
 	"testing"
 	"time"
 
@@ -224,4 +225,25 @@ func TestBuildTelemetryAttributesMethod(t *testing.T) {
 	if requestDuration != 100 {
 		t.Fatalf("Expected requestDuration to be 100, but got %v", requestDuration)
 	}
+}
+
+// Run this test with the "-race" flag.
+//
+//	go test -race -run ^TestGetRace$ github.com/openfga/go-sdk/telemetry
+func TestGetRace(t *testing.T) {
+	t.Parallel()
+
+	var wg sync.WaitGroup
+
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			Get(TelemetryFactoryParameters{})
+		}()
+	}
+
+	wg.Wait()
 }


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->



## Description
<!-- Provide a detailed description of the changes -->

Fixes data race on `TelemetryInstances`.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

- #134 
- Fixes #135 

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

If you haven't done so yet, we would appreciate it if you could star the [OpenFGA repository](https://github.com/openfga/openfga). :) 
