### PR TITLE
fix: Fix data race issue on metrics Counters and Histograms

### DIFF
--- a/telemetry/metrics.go
+++ b/telemetry/metrics.go
@@ -3,16 +3,19 @@ package telemetry
 import (
 	"context"
 	"net/http"
+	"sync"
 	"time"
 
 	"go.opentelemetry.io/otel/metric"
 )
 
 type Metrics struct {
-	Meter         metric.Meter
-	Counters      map[string]metric.Int64Counter
-	Histograms    map[string]metric.Float64Histogram
-	Configuration *MetricsConfiguration
+	Meter          metric.Meter
+	countersLock   sync.Mutex
+	Counters       map[string]metric.Int64Counter
+	histogramsLock sync.Mutex
+	Histograms     map[string]metric.Float64Histogram
+	Configuration  *MetricsConfiguration
 }
 
 type MetricsInterface interface {
@@ -25,6 +28,9 @@ type MetricsInterface interface {
 }
 
 func (m *Metrics) GetCounter(name string, description string) (metric.Int64Counter, error) {
+	m.countersLock.Lock()
+	defer m.countersLock.Unlock()
+
 	if counter, exists := m.Counters[name]; exists {
 		return counter, nil
 	}
@@ -34,6 +40,9 @@ func (m *Metrics) GetCounter(name string, description string) (metric.Int64Count
 }
 
 func (m *Metrics) GetHistogram(name string, description string, unit string) (metric.Float64Histogram, error) {
+	m.histogramsLock.Lock()
+	defer m.histogramsLock.Unlock()
+
 	if histogram, exists := m.Histograms[name]; exists {
 		return histogram, nil
 	}


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

Fix data race issue in `metrics.go` caused by unlocked access to the `Counters` and `Histograms` maps.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

Similar to fix provided in #136 

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

If you haven't done so yet, we would appreciate it if you could star the [OpenFGA repository](https://github.com/openfga/openfga). :) 
