### PR TITLE
Quality of life string conversions for FgaObject

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -14,7 +14,9 @@ package openfga
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/url"
+	"strings"
 	"time"
 )
 
@@ -340,4 +342,21 @@ func IsWellFormedUri(uriString string) bool {
 	}
 
 	return true
+}
+
+func (o FgaObject) String() string {
+	return fmt.Sprintf("%s:%s", o.Type, o.Id)
+}
+
+func FgaObjectFromString(objectString string) (*FgaObject, error) {
+	if objectString == "" {
+		return nil, fmt.Errorf("failed parsing FgaObject, cannot build FgaObject from empty string")
+	}
+	objectTokens := strings.Split(objectString, ":")
+	if len(objectTokens) != 2 {
+		return nil, fmt.Errorf("failed parsing FgaObject, invalid FgaObject string")
+	}
+	objectType := objectTokens[0]
+	objectId := objectTokens[1]
+	return NewFgaObject(objectType, objectId), nil
 }


### PR DESCRIPTION
Quality of life functions for `FgaObject` from and to `string` convesion

Using FGA on the backend, I found myself converting a lot between the two so I implemented these easy but handy helper functions. Also as a bonus makes `FgaObject` compatible with `fmt.Stringer interface`

`func (o FgaObject) String() string`
`func FgaObjectFromString(s string) (*FgaObject, error)`

## Description
<!-- Provide a detailed description of the changes -->

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

If you haven't done so yet, we would appreciate it if you could star the [OpenFGA repository](https://github.com/openfga/openfga). :) 
