### PR TITLE
fix: api client should set default telemetry if not specified

### DIFF
--- a/api_client.go
+++ b/api_client.go
@@ -65,6 +65,9 @@ type service struct {
 // NewAPIClient creates a new API client. Requires a userAgent string describing your application.
 // optionally a custom http.Client to allow for advanced features such as caching.
 func NewAPIClient(cfg *Configuration) *APIClient {
+	if cfg.Telemetry == nil {
+		cfg.Telemetry = telemetry.DefaultTelemetryConfiguration()
+	}
 	if cfg.HTTPClient == nil {
 		if cfg.Credentials == nil {
 			cfg.HTTPClient = http.DefaultClient

--- a/api_client_test.go
+++ b/api_client_test.go
@@ -1,0 +1,23 @@
+package openfga
+
+import (
+	"github.com/openfga/go-sdk/telemetry"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestApiClientCreatedWithDefaultTelemetry(t *testing.T) {
+	cfg := Configuration{
+		HTTPClient: &http.Client{Timeout: 10 * time.Second},
+		ApiUrl:     "http://localhost:8080/",
+	}
+	_ = NewAPIClient(&cfg)
+
+	telemetry1 := telemetry.Get(telemetry.TelemetryFactoryParameters{Configuration: cfg.Telemetry})
+	telemetry2 := telemetry.Get(telemetry.TelemetryFactoryParameters{Configuration: cfg.Telemetry})
+
+	if telemetry1 != telemetry2 {
+		t.Fatalf("Telemetry instance should be the same")
+	}
+}


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

Ensure that a default telemetry instance is created when creating an API client directly.

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

When a `Configuration` is created via `NewConfiguration`, we ensure that a default telemetry is created if not specified. However, when creating a `Configuration` directly as shown in [#466](https://github.com/openfga/sdk-generator/issues/466), no telemetry is created. This causes `telemetry.Get` to create a new telemetry instance on each call (e.g., each API call), which causes the map to grow unbounded.

This change ensures that a default Telemetry instance is created when creating a new `APIClient`.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

https://github.com/openfga/sdk-generator/issues/466

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

