### PR TITLE
fix: Do not ignore request level storeId in non-transactional write

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -445,20 +445,17 @@ type SdkClient interface {
 	 */
 	SetAuthorizationModelId(authorizationModelId string) error
 
-
 	/*
 	 * GetAuthorizationModelId retrieves the Authorization Model ID for an OpenFGAClient.
 	 * @return string
 	 */
 	GetAuthorizationModelId() (string, error)
 
-
 	/*
 	 * SetStoreId allows setting the Store ID for an OpenFGAClient.
 	 * @param string storeId - The Store ID to set.
 	 */
 	SetStoreId(storeId string) error
-
 
 	/*
 	 * GetStoreId retrieves the Store ID set in the OpenFGAClient.
@@ -1605,6 +1602,7 @@ func (client *OpenFgaClient) WriteExecute(request SdkClientWriteRequestInterface
 				},
 				options: &ClientWriteOptions{
 					AuthorizationModelId: authorizationModelId,
+					StoreId:              request.GetStoreIdOverride(),
 				},
 			})
 
@@ -1648,6 +1646,7 @@ func (client *OpenFgaClient) WriteExecute(request SdkClientWriteRequestInterface
 				},
 				options: &ClientWriteOptions{
 					AuthorizationModelId: authorizationModelId,
+					StoreId:              request.GetStoreIdOverride(),
 				},
 			})
 


### PR DESCRIPTION
Fix: Do not ignore request level storeId override in non-transactional write

## Description
Currently, the request level store ID is ignored in non-transactional write requests, resulting in the error "storeId is required and must be specified". This PR fixes the issue by passing the storeId to the WriteExecute call.

This PR
- passes the request level storeId to the WriteExecute call
- extends the unit test covering the storeId override case

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected

