### PR TITLE
fix: populate start_time in request

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1230,8 +1230,11 @@ func (client *OpenFgaClient) ReadChangesExecute(request SdkClientReadChangesRequ
 		req = req.ContinuationToken(*continuationToken)
 	}
 	requestBody := request.GetBody()
-	if requestBody != nil {
+	if requestBody.Type != "" {
 		req = req.Type_(requestBody.Type)
+	}
+	if !requestBody.StartTime.IsZero() {
+		req = req.StartTime(requestBody.StartTime)
 	}
 
 	data, _, err := req.Execute()

--- a/client/client.go
+++ b/client/client.go
@@ -1230,10 +1230,10 @@ func (client *OpenFgaClient) ReadChangesExecute(request SdkClientReadChangesRequ
 		req = req.ContinuationToken(*continuationToken)
 	}
 	requestBody := request.GetBody()
-	if requestBody.Type != "" {
+	if requestBody != nil &&  requestBody.Type != "" {
 		req = req.Type_(requestBody.Type)
 	}
-	if !requestBody.StartTime.IsZero() {
+	if requestBody != nil &&  !requestBody.StartTime.IsZero() {
 		req = req.StartTime(requestBody.StartTime)
 	}
 


### PR DESCRIPTION
## Description
Fix for start time not checked in request body

Addresses: https://github.com/openfga/sdk-generator/issues/483

## References
Also backported to sdk-generator: https://github.com/openfga/sdk-generator/pull/484

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

