### PR TITLE
feat: support assertions with context and contextual tuples

### DIFF
--- a/README.md
+++ b/README.md
@@ -889,6 +889,16 @@ requestBody := ClientWriteAssertionsRequest{
         Relation:    "can_view",
         Object:      "document:0192ab2a-d83f-756d-9397-c5ed9f3cb69a",
         Expectation: true,
+        Context: &map[string]interface{}{
+            "context": "value",
+        },
+        ContextualTuples: []ClientContextualTupleKey{
+            {
+                User:     "user:81684243-9356-4421-8fbf-a4f8d36aa31b",
+                Relation: "can_view",
+                Object:   "document:0192ab2a-d83f-756d-9397-c5ed9f3cb69a",
+            },
+        },
     },
 }
 data, err := fgaClient.WriteAssertions(context.Background()).

--- a/client/client.go
+++ b/client/client.go
@@ -2682,16 +2682,18 @@ type SdkClientWriteAssertionsRequestInterface interface {
 }
 
 type ClientAssertion struct {
-	User        string `json:"user,omitempty"`
-	Relation    string `json:"relation,omitempty"`
-	Object      string `json:"object,omitempty"`
-	Expectation bool   `json:"expectation,omitempty"`
+	User             string                     `json:"user,omitempty"`
+	Relation         string                     `json:"relation,omitempty"`
+	Object           string                     `json:"object,omitempty"`
+	Expectation      bool                       `json:"expectation,omitempty"`
+	Context          *map[string]interface{}    `json:"context,omitempty"`
+	ContextualTuples []ClientContextualTupleKey `json:"contextual_tuples,omitempty"`
 }
 
 type ClientWriteAssertionsRequest = []ClientAssertion
 
 func (clientAssertion ClientAssertion) ToAssertion() fgaSdk.Assertion {
-	return fgaSdk.Assertion{
+	assertion := fgaSdk.Assertion{
 		TupleKey: fgaSdk.AssertionTupleKey{
 			User:     clientAssertion.User,
 			Relation: clientAssertion.Relation,
@@ -2699,6 +2701,16 @@ func (clientAssertion ClientAssertion) ToAssertion() fgaSdk.Assertion {
 		},
 		Expectation: clientAssertion.Expectation,
 	}
+
+	if clientAssertion.Context != nil {
+		assertion.Context = clientAssertion.Context
+	}
+
+	if clientAssertion.ContextualTuples != nil {
+		assertion.ContextualTuples = &clientAssertion.ContextualTuples
+	}
+
+	return assertion
 }
 
 type ClientWriteAssertionsOptions struct {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -21,7 +21,7 @@ import (
 	"time"
 
 	"github.com/jarcoal/httpmock"
-	"github.com/openfga/go-sdk"
+	openfga "github.com/openfga/go-sdk"
 	. "github.com/openfga/go-sdk/client"
 )
 
@@ -3002,7 +3002,7 @@ func TestOpenFgaClient(t *testing.T) {
 		modelId := "01GAHCE4YVKPQEKZQHT2R89MQV"
 		test := TestDefinition{
 			Name:           "ReadAssertions",
-			JsonResponse:   fmt.Sprintf(`{"assertions":[{"tuple_key":{"user":"user:anna","relation":"can_view","object":"document:0192ab2a-d83f-756d-9397-c5ed9f3cb69a"},"expectation":true}],"authorization_model_id":"%s"}`, modelId),
+			JsonResponse:   fmt.Sprintf(`{"assertions":[{"tuple_key":{"user":"user:anna","relation":"can_view","object":"document:0192ab2a-d83f-756d-9397-c5ed9f3cb69a"},"expectation":true}],"authorization_model_id":"%s","context":{"context":"value"},"contextual_tuples":[{"object":"document:0192ab2a-d83f-756d-9397-c5ed9f3cb69a","relation":"can_view","user":"user:81684243-9356-4421-8fbf-a4f8d36aa31b"}]}`, modelId),
 			ResponseStatus: http.StatusOK,
 			Method:         http.MethodGet,
 			RequestPath:    "assertions",
@@ -3111,6 +3111,16 @@ func TestOpenFgaClient(t *testing.T) {
 				Relation:    "can_view",
 				Object:      "document:0192ab2a-d83f-756d-9397-c5ed9f3cb69a",
 				Expectation: true,
+				Context: &map[string]interface{}{
+					"context": "value",
+				},
+				ContextualTuples: []ClientContextualTupleKey{
+					{
+						User:     "user:81684243-9356-4421-8fbf-a4f8d36aa31b",
+						Relation: "can_view",
+						Object:   "document:0192ab2a-d83f-756d-9397-c5ed9f3cb69a",
+					},
+				},
 			},
 		}
 		options := ClientWriteAssertionsOptions{

--- a/example/example1/example1.go
+++ b/example/example1/example1.go
@@ -250,6 +250,7 @@ func mainInner() error {
 		User:     "user:anne",
 		Relation: "viewer",
 		Type:     "document",
+		Context:  &map[string]interface{}{"ViewCount": 100},
 	}).Execute()
 	fmt.Printf("Response: Objects = %v\n", listObjectsResponse.Objects)
 
@@ -283,6 +284,14 @@ func mainInner() error {
 			Relation:    "writer",
 			Object:      "document:budget",
 			Expectation: true,
+			Context:     &map[string]interface{}{"Name": "Roadmap", "Type": "document"},
+			ContextualTuples: []client.ClientContextualTupleKey{
+				{
+					User:     "user:carl",
+					Relation: "writer",
+					Object:   "document:budget",
+				},
+			},
 		},
 		{
 			User:        "user:anne",
@@ -302,7 +311,7 @@ func mainInner() error {
 	if err != nil {
 		return err
 	}
-	fmt.Printf("Assertions: %v\n", assertions)
+	fmt.Printf("Assertions: %v\n", assertions.GetAssertions())
 
 	// DeleteStore
 	fmt.Println("Deleting Current Store")


### PR DESCRIPTION
## Description

Adds `Context` and `ContextualTuples` support to `Assertions` in the `OpenFGAClient`

## References

https://github.com/openfga/sdk-generator/issues/449
https://github.com/openfga/api/pull/185

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected

