### PR TITLE
release: v0.6.5

### DIFF
--- a/.openapi-generator/FILES
+++ b/.openapi-generator/FILES
@@ -5,8 +5,6 @@
 .github/ISSUE_TEMPLATE/config.yaml
 .github/ISSUE_TEMPLATE/feature_request.yaml
 .github/dependabot.yaml
-.github/workflows/main.yaml
-.github/workflows/semgrep.yaml
 .gitignore
 CHANGELOG.md
 CONTRIBUTING.md
@@ -15,6 +13,7 @@ NOTICE.txt
 README.md
 VERSION.txt
 api_client.go
+api_client_test.go
 api_open_fga.go
 api_open_fga_test.go
 client/client.go

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.6.5
+
+### [0.6.5](https://github.com/openfga/go-sdk/compare/v0.6.4...v0.6.5) (2025-02-06)
+
+- feat: support assertions with context and contextual tuples (#169)
+- fix: populate start_time in request (#166)
+
 ## v0.6.4
 
 ### [0.6.4](https://github.com/openfga/go-sdk/compare/v0.6.3...v0.6.4) (2025-01-29)

--- a/client/client.go
+++ b/client/client.go
@@ -444,19 +444,16 @@ type SdkClient interface {
 	 * @param string authorizationModelId - The Authorization Model ID to set.
 	 */
 	SetAuthorizationModelId(authorizationModelId string) error
-
 	/*
 	 * GetAuthorizationModelId retrieves the Authorization Model ID for an OpenFGAClient.
 	 * @return string
 	 */
 	GetAuthorizationModelId() (string, error)
-
 	/*
 	 * SetStoreId allows setting the Store ID for an OpenFGAClient.
 	 * @param string storeId - The Store ID to set.
 	 */
 	SetStoreId(storeId string) error
-
 	/*
 	 * GetStoreId retrieves the Store ID set in the OpenFGAClient.
 	 * @return string
@@ -1230,10 +1227,10 @@ func (client *OpenFgaClient) ReadChangesExecute(request SdkClientReadChangesRequ
 		req = req.ContinuationToken(*continuationToken)
 	}
 	requestBody := request.GetBody()
-	if requestBody != nil &&  requestBody.Type != "" {
+	if requestBody != nil && requestBody.Type != "" {
 		req = req.Type_(requestBody.Type)
 	}
-	if requestBody != nil &&  !requestBody.StartTime.IsZero() {
+	if requestBody != nil && !requestBody.StartTime.IsZero() {
 		req = req.StartTime(requestBody.StartTime)
 	}
 
@@ -2701,15 +2698,12 @@ func (clientAssertion ClientAssertion) ToAssertion() fgaSdk.Assertion {
 		},
 		Expectation: clientAssertion.Expectation,
 	}
-
 	if clientAssertion.Context != nil {
 		assertion.Context = clientAssertion.Context
 	}
-
 	if clientAssertion.ContextualTuples != nil {
 		assertion.ContextualTuples = &clientAssertion.ContextualTuples
 	}
-
 	return assertion
 }
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -21,7 +21,7 @@ import (
 	"time"
 
 	"github.com/jarcoal/httpmock"
-	openfga "github.com/openfga/go-sdk"
+	"github.com/openfga/go-sdk"
 	. "github.com/openfga/go-sdk/client"
 )
 

--- a/configuration.go
+++ b/configuration.go
@@ -20,9 +20,9 @@ import (
 )
 
 const (
-	SdkVersion = "0.6.4"
+	SdkVersion = "0.6.5"
 
-	defaultUserAgent = "openfga-sdk go/0.6.4"
+	defaultUserAgent = "openfga-sdk go/0.6.5"
 )
 
 // RetryParams configures configuration for retry in case of HTTP too many request

--- a/example/example1/go.mod
+++ b/example/example1/go.mod
@@ -2,7 +2,7 @@ module example1
 
 go 1.22.2
 
-require github.com/openfga/go-sdk v0.6.4
+require github.com/openfga/go-sdk v0.6.5
 
 require (
 	github.com/go-logr/logr v1.4.2 // indirect
@@ -14,4 +14,4 @@ require (
 )
 
 // To reference local build, uncomment below and run `go mod tidy`
-replace github.com/openfga/go-sdk v0.6.4 => ../../
+replace github.com/openfga/go-sdk v0.6.5 => ../../

--- a/example/opentelemetry/go.mod
+++ b/example/opentelemetry/go.mod
@@ -3,11 +3,11 @@ module openfga-opentelemetry-example
 go 1.21
 
 // To reference local build, uncomment below and run `go mod tidy`
-replace github.com/openfga/go-sdk v0.6.4 => ../../
+replace github.com/openfga/go-sdk v0.6.5 => ../../
 
 require (
 	github.com/joho/godotenv v1.5.1
-	github.com/openfga/go-sdk v0.6.4
+	github.com/openfga/go-sdk v0.6.5
 	go.opentelemetry.io/otel v1.29.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.29.0
 	go.opentelemetry.io/otel/sdk v1.29.0


### PR DESCRIPTION
## Description

```
- feat: support assertions with context and contextual tuples (#169)
- fix: populate start_time in request (#166)
```

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

