### PR TITLE
release: v0.6.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,17 @@
 # Changelog
 
-## [Unreleased](https://github.com/openfga/go-sdk/compare/v0.6.5...HEAD)
+## [Unreleased](https://github.com/openfga/go-sdk/compare/v0.6.6...HEAD)
 
+## v0.6.6
+
+### [0.6.6](https://github.com/openfga/go-sdk/compare/v0.6.5...v0.6.6) (2025-03-31)
 - feat: fix and improve retries and rate limit handling. (#176)
   The SDK now retries on network errors and the default retry handling has been fixed
   for both the calls to the OpenFGA API and the API Token Issuer for those using ClientCredentials
   The SDK now also respects the rate limit headers (`Retry-After`) returned by the server and will retry the request after the specified time.
   If the header is not sent or on network errors, it will fall back to exponential backoff.
 - feat: retry on network errors when calling the token issuer (#182)
+- feat: add upport for server-side BatchCheck (#187)
 - chore: log retry attempts when debug mode is enabled (#182)
 
 ## v0.6.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   If the header is not sent or on network errors, it will fall back to exponential backoff.
 - feat: retry on network errors when calling the token issuer (#182)
 - feat: add support for server-side BatchCheck (#187)
+- fix: use defaults when transaction options were only partially set (#183)
 - chore: log retry attempts when debug mode is enabled (#182)
 
 ## v0.6.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
   The SDK now also respects the rate limit headers (`Retry-After`) returned by the server and will retry the request after the specified time.
   If the header is not sent or on network errors, it will fall back to exponential backoff.
 - feat: retry on network errors when calling the token issuer (#182)
-- feat: add upport for server-side BatchCheck (#187)
+- feat: add support for server-side BatchCheck (#187)
 - chore: log retry attempts when debug mode is enabled (#182)
 
 ## v0.6.5

--- a/configuration.go
+++ b/configuration.go
@@ -21,9 +21,9 @@ import (
 )
 
 const (
-	SdkVersion = "0.6.5"
+	SdkVersion = "0.6.6"
 
-	defaultUserAgent = "openfga-sdk go/0.6.5"
+	defaultUserAgent = "openfga-sdk go/0.6.6"
 )
 
 // RetryParams provides configuration for retries in case of server errors

--- a/example/example1/go.mod
+++ b/example/example1/go.mod
@@ -4,7 +4,7 @@ go 1.23.0
 
 toolchain go1.24.0
 
-require github.com/openfga/go-sdk v0.6.5
+require github.com/openfga/go-sdk v0.6.6
 
 require (
 	github.com/go-logr/logr v1.4.2 // indirect
@@ -17,4 +17,4 @@ require (
 )
 
 // To reference local build, uncomment below and run `go mod tidy`
-replace github.com/openfga/go-sdk v0.6.5 => ../../
+replace github.com/openfga/go-sdk v0.6.6 => ../../

--- a/example/opentelemetry/go.mod
+++ b/example/opentelemetry/go.mod
@@ -5,11 +5,11 @@ go 1.23.0
 toolchain go1.24.0
 
 // To reference local build, uncomment below and run `go mod tidy`
-replace github.com/openfga/go-sdk v0.6.5 => ../../
+replace github.com/openfga/go-sdk v0.6.6 => ../../
 
 require (
 	github.com/joho/godotenv v1.5.1
-	github.com/openfga/go-sdk v0.6.5
+	github.com/openfga/go-sdk v0.6.6
 	go.opentelemetry.io/otel v1.35.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.35.0
 	go.opentelemetry.io/otel/sdk v1.35.0


### PR DESCRIPTION
## Description
Release 0.6.6 for go-sdk including:
- feat: fix and improve retries and rate limit handling. (https://github.com/openfga/go-sdk/pull/176)
  The SDK now retries on network errors and the default retry handling has been fixed
  for both the calls to the OpenFGA API and the API Token Issuer for those using ClientCredentials
  The SDK now also respects the rate limit headers (`Retry-After`) returned by the server and will retry the request after the specified time.
  If the header is not sent or on network errors, it will fall back to exponential backoff.
- feat: retry on network errors when calling the token issuer (https://github.com/openfga/go-sdk/pull/182)
- feat: add upport for server-side BatchCheck (https://github.com/openfga/go-sdk/pull/187)
- chore: log retry attempts when debug mode is enabled (https://github.com/openfga/go-sdk/pull/182)
- 
## References
https://github.com/openfga/go-sdk/pull/176
https://github.com/openfga/go-sdk/pull/182
https://github.com/openfga/go-sdk/pull/187

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

