### PR TITLE
chore(ci): restrict semgrep workflow permissions to only read contents

### DIFF
--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -6,6 +6,8 @@ on:
 jobs:
   semgrep:
     name: Scan
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     container:
       image: returntocorp/semgrep


### PR DESCRIPTION
Potential fix for [https://github.com/openfga/go-sdk/security/code-scanning/1](https://github.com/openfga/go-sdk/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the job definition for `semgrep` in `.github/workflows/semgrep.yaml`. The minimal required permission for running Semgrep and checking out code is typically `contents: read`, which allows the job to read repository contents but not modify them. This block should be added directly under the job name (`name: Scan`) and before other job-level keys such as `runs-on`. No additional imports or definitions are required; this is a YAML configuration change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
