### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,4 +1,6 @@
 name: Build, Test and Publish
+permissions:
+  contents: read
 
 on:
   merge_group:
@@ -40,6 +42,8 @@ jobs:
           slug: openfga/go-sdk
 
   create-release:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [test]


### PR DESCRIPTION
Potential fix for [https://github.com/openfga/go-sdk/security/code-scanning/2](https://github.com/openfga/go-sdk/security/code-scanning/2)

To fix the problem, add a `permissions` block to the workflow. The best way is to set the minimal required permissions at the root level, which will apply to all jobs unless overridden. For most jobs, `contents: read` is sufficient. For jobs that need to create releases (such as `create-release`), you may need to grant `contents: write` or `packages: write` as appropriate. In this case, add `permissions: contents: read` at the root of the workflow, and override it for the `create-release` job with `permissions: contents: write`. Edit the `.github/workflows/main.yaml` file, adding the root-level permissions block after the `name` field, and a job-level permissions block for `create-release`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
