### PR TITLE
feat: add per-request headers support

### DIFF
--- a/api_client.go
+++ b/api_client.go
@@ -288,6 +288,11 @@ func (c *APIClient) prepareRequest(
 	}
 
 	if ctx != nil {
+		if headers, ok := HeadersFromContext(ctx); ok {
+			for h, v := range headers {
+				localVarRequest.Header.Set(h, v)
+			}
+		}
 		// add context to the request
 		localVarRequest = localVarRequest.WithContext(ctx)
 	}

--- a/headers.go
+++ b/headers.go
@@ -1,0 +1,19 @@
+package openfga
+
+import "context"
+
+type headersContextKey struct{}
+
+// ContextWithHeaders returns a context carrying the provided headers.
+func ContextWithHeaders(ctx context.Context, headers map[string]string) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, headersContextKey{}, headers)
+}
+
+// HeadersFromContext extracts headers from the context if present.
+func HeadersFromContext(ctx context.Context) (map[string]string, bool) {
+	headers, ok := ctx.Value(headersContextKey{}).(map[string]string)
+	return headers, ok
+}


### PR DESCRIPTION
## Summary
- allow passing custom headers via per-request options
- propagate headers through API client and request context
- cover header usage with unit test

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689e767f9f2883228dcf39ab73b4c685

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Support custom HTTP headers per request across all client operations (read, write, checks, list, expand, assertions, etc.).
  * Headers provided per request are propagated through parallel, batched, and chunked operations.
  * When duplicate header names exist, per-request headers take precedence.
* Tests
  * Added tests verifying per-request headers (e.g., correlation IDs) are sent with requests and respected during operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->