### PR TITLE
feat: support per-request headers and connection options

### DIFF
--- a/.openapi-generator/FILES
+++ b/.openapi-generator/FILES
@@ -13,9 +13,11 @@ README.md
 VERSION.txt
 api_client.go
 api_client_test.go
+api_headers_test.go
 api_open_fga.go
 api_open_fga_test.go
 client/client.go
+client/client_headers_test.go
 client/client_test.go
 client/errors.go
 configuration.go

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased](https://github.com/openfga/go-sdk/compare/v0.7.1...HEAD)
 
+- feat: add support for custom headers per request
 - feat: add contextual tuples support in Expand requests
 
 ## v0.7.1

--- a/README.md
+++ b/README.md
@@ -217,6 +217,46 @@ func main() {
 }
 ```
 
+### Custom Headers
+
+#### Default Headers
+You can set default headers that will be sent with every request during client initialization:
+
+```golang
+fgaClient, err := client.NewSdkClient(&client.ClientConfiguration{
+    ApiUrl:               os.Getenv("FGA_API_URL"),
+    StoreId:              os.Getenv("FGA_STORE_ID"),
+    AuthorizationModelId: os.Getenv("FGA_MODEL_ID"),
+    DefaultHeaders: map[string]string{
+        "X-Custom-Header": "default-value",
+        "X-Request-Source": "my-app",
+    },
+})
+```
+
+#### Per-Request Headers
+
+You can also send custom headers on a per-request basis by using the `Options` parameter. Custom headers will override any default headers set in the client configuration.
+
+```golang
+// Add custom headers to a specific request
+checkResponse, err := fgaClient.Check(context.Background()).
+    Body(client.ClientCheckRequest{
+        User:     "user:anne",
+        Relation: "viewer",
+        Object:   "document:roadmap",
+    }).
+    Options(client.ClientCheckOptions{
+        RequestOptions: client.RequestOptions{
+            Headers: map[string]string{
+                "X-Request-ID": "123e4567-e89b-12d3-a456-426614174000",
+                "X-Custom-Header": "custom-value", // these override any default headers set
+            },
+        },
+    }).
+    Execute()
+```
+
 
 ### Get your Store ID
 

--- a/api_client.go
+++ b/api_client.go
@@ -284,7 +284,9 @@ func (c *APIClient) prepareRequest(
 	localVarRequest.Header.Set("User-Agent", c.cfg.UserAgent)
 
 	for header, value := range c.cfg.DefaultHeaders {
-		localVarRequest.Header.Set(header, value)
+		if localVarRequest.Header.Get(header) == "" {
+			localVarRequest.Header.Set(header, value)
+		}
 	}
 
 	if ctx != nil {

--- a/api_headers_test.go
+++ b/api_headers_test.go
@@ -1,0 +1,838 @@
+package openfga_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	openfga "github.com/openfga/go-sdk"
+)
+
+// Test helpers and setup
+
+// Constants to avoid duplication
+const (
+	apiDefaultHeaderName     = "Default-Header"
+	apiDefaultHeaderValue    = "default-value"
+	apiOverriddenValue       = "overridden-value"
+	apiCustomHeaderName      = "X-Custom-Header"
+	apiCustomHeaderValue     = "custom-value"
+	apiTestUser              = "user:anne"
+	apiTestRelation          = "viewer"
+	apiTestObject            = "document:roadmap"
+	apiTestStoreId           = "01H0H015178Y2V4CX10C2KGHF4"
+	apiRequestFailedMsg      = "API request failed: %v"
+	apiExpectedCustomMsg     = "Expected X-Custom-Header to be 'custom-value', got '%s'"
+	apiExpectedOverriddenMsg = "Expected Default-Header to be overridden to 'overridden-value', got '%s'"
+	apiExpectedDefaultMsg    = "Expected Default-Header to be 'default-value', got '%s'"
+)
+
+// createAPITestServer creates a test server that captures headers and returns appropriate responses
+func createAPITestServer(t *testing.T, capturedHeaders *map[string]string, responseBody string) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*capturedHeaders = make(map[string]string)
+		for name, values := range r.Header {
+			if len(values) > 0 {
+				(*capturedHeaders)[name] = values[0]
+			}
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(responseBody))
+	}))
+}
+
+// createAPITestClient creates a test API client with the given server URL and default headers
+func createAPITestClient(t *testing.T, serverURL string, defaultHeaders map[string]string) *openfga.APIClient {
+	t.Helper()
+
+	config, err := openfga.NewConfiguration(openfga.Configuration{
+		ApiUrl:         serverURL,
+		DefaultHeaders: defaultHeaders,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create API configuration: %v", err)
+	}
+
+	return openfga.NewAPIClient(config)
+}
+
+// Misc tests
+
+// Test RequestOptions structure directly at API level
+func TestAPIRequestOptionsStructure(t *testing.T) {
+	t.Run("RequestOptionsWithAllFields", func(t *testing.T) {
+		options := openfga.RequestOptions{
+			Headers: map[string]string{
+				"Test-Header": "test-value",
+			},
+			MaxRetry:    openfga.PtrInt(3),
+			MinWaitInMs: openfga.PtrInt(1000),
+		}
+
+		if options.Headers["Test-Header"] != "test-value" {
+			t.Errorf("Expected Test-Header to be 'test-value', got '%s'", options.Headers["Test-Header"])
+		}
+
+		if options.MaxRetry == nil || *options.MaxRetry != 3 {
+			t.Errorf("Expected MaxRetry to be 3, got %v", options.MaxRetry)
+		}
+
+		if options.MinWaitInMs == nil || *options.MinWaitInMs != 1000 {
+			t.Errorf("Expected MinWaitInMs to be 1000, got %v", options.MinWaitInMs)
+		}
+	})
+
+	t.Run("RequestOptionsWithNilHeaders", func(t *testing.T) {
+		options := openfga.RequestOptions{
+			Headers:     nil,
+			MaxRetry:    openfga.PtrInt(3),
+			MinWaitInMs: openfga.PtrInt(1000),
+		}
+
+		if options.Headers != nil {
+			t.Errorf("Expected Headers to be nil, got %v", options.Headers)
+		}
+	})
+
+	t.Run("RequestOptionsWithEmptyHeaders", func(t *testing.T) {
+		options := openfga.RequestOptions{
+			Headers:     map[string]string{},
+			MaxRetry:    openfga.PtrInt(3),
+			MinWaitInMs: openfga.PtrInt(1000),
+		}
+
+		if len(options.Headers) != 0 {
+			t.Errorf("Expected Headers to be empty, got %v", options.Headers)
+		}
+	})
+}
+
+// Test header precedence and merging behavior
+func TestAPIHeaderPrecedenceHandling(t *testing.T) {
+	t.Run("CustomHeadersOverrideDefaults", func(t *testing.T) {
+		var capturedHeaders map[string]string
+		server := createAPITestServer(t, &capturedHeaders, `{"allowed": true}`)
+		defer server.Close()
+
+		client := createAPITestClient(t, server.URL, map[string]string{
+			"Header-1": "default-1",
+			"Header-2": "default-2",
+			"Header-3": "default-3",
+		})
+
+		_, _, err := client.OpenFgaApi.Check(context.Background(), apiTestStoreId).
+			Body(openfga.CheckRequest{
+				TupleKey: openfga.CheckRequestTupleKey{
+					User:     apiTestUser,
+					Relation: apiTestRelation,
+					Object:   apiTestObject,
+				},
+			}).
+			Options(openfga.RequestOptions{
+				Headers: map[string]string{
+					"Header-1": "overridden-1", // Override the default
+					"Header-4": "custom-4",
+				},
+			}).
+			Execute()
+
+		if err != nil {
+			t.Fatalf(apiRequestFailedMsg, err)
+		}
+
+		if capturedHeaders["Header-1"] != "overridden-1" {
+			t.Errorf("Expected Header-1 to be 'overridden-1', got '%s'", capturedHeaders["Header-1"])
+		}
+
+		if capturedHeaders["Header-2"] != "default-2" {
+			t.Errorf("Expected Header-2 to be 'default-2', got '%s'", capturedHeaders["Header-2"])
+		}
+
+		if capturedHeaders["Header-3"] != "default-3" {
+			t.Errorf("Expected Header-3 to be 'default-3', got '%s'", capturedHeaders["Header-3"])
+		}
+
+		if capturedHeaders["Header-4"] != "custom-4" {
+			t.Errorf("Expected Header-4 to be 'custom-4', got '%s'", capturedHeaders["Header-4"])
+		}
+	})
+}
+
+// Test the header handling for the methods
+
+func TestCheckAPIMethodHeaderHandling(t *testing.T) {
+	t.Run("CheckAPIWithCustomHeaders", func(t *testing.T) {
+		var capturedHeaders map[string]string
+		server := createAPITestServer(t, &capturedHeaders, `{"allowed": true}`)
+		defer server.Close()
+
+		client := createAPITestClient(t, server.URL, map[string]string{
+			apiDefaultHeaderName: apiDefaultHeaderValue,
+		})
+
+		_, _, err := client.OpenFgaApi.Check(context.Background(), apiTestStoreId).
+			Body(openfga.CheckRequest{
+				TupleKey: openfga.CheckRequestTupleKey{
+					User:     apiTestUser,
+					Relation: apiTestRelation,
+					Object:   apiTestObject,
+				},
+			}).
+			Options(openfga.RequestOptions{
+				Headers: map[string]string{
+					apiCustomHeaderName:  apiCustomHeaderValue,
+					apiDefaultHeaderName: apiOverriddenValue,
+				},
+			}).
+			Execute()
+
+		if err != nil {
+			t.Fatalf(apiRequestFailedMsg, err)
+		}
+
+		if capturedHeaders[apiCustomHeaderName] != apiCustomHeaderValue {
+			t.Errorf(apiExpectedCustomMsg, capturedHeaders[apiCustomHeaderName])
+		}
+
+		if capturedHeaders[apiDefaultHeaderName] != apiOverriddenValue {
+			t.Errorf(apiExpectedOverriddenMsg, capturedHeaders[apiDefaultHeaderName])
+		}
+	})
+
+	t.Run("CheckAPIWithoutCustomHeaders", func(t *testing.T) {
+		var capturedHeaders map[string]string
+		server := createAPITestServer(t, &capturedHeaders, `{"allowed": true}`)
+		defer server.Close()
+
+		client := createAPITestClient(t, server.URL, map[string]string{
+			apiDefaultHeaderName: apiDefaultHeaderValue,
+		})
+
+		_, _, err := client.OpenFgaApi.Check(context.Background(), apiTestStoreId).
+			Body(openfga.CheckRequest{
+				TupleKey: openfga.CheckRequestTupleKey{
+					User:     apiTestUser,
+					Relation: apiTestRelation,
+					Object:   apiTestObject,
+				},
+			}).
+			Execute()
+
+		if err != nil {
+			t.Fatalf(apiRequestFailedMsg, err)
+		}
+
+		if capturedHeaders[apiDefaultHeaderName] != apiDefaultHeaderValue {
+			t.Errorf(apiExpectedDefaultMsg, capturedHeaders[apiDefaultHeaderName])
+		}
+
+		if _, exists := capturedHeaders[apiCustomHeaderName]; exists {
+			t.Error("Did not expect X-Custom-Header to be present")
+		}
+	})
+
+	t.Run("CheckAPIWithEmptyHeaders", func(t *testing.T) {
+		var capturedHeaders map[string]string
+		server := createAPITestServer(t, &capturedHeaders, `{"allowed": true}`)
+		defer server.Close()
+
+		client := createAPITestClient(t, server.URL, nil)
+
+		_, _, err := client.OpenFgaApi.Check(context.Background(), apiTestStoreId).
+			Body(openfga.CheckRequest{
+				TupleKey: openfga.CheckRequestTupleKey{
+					User:     apiTestUser,
+					Relation: apiTestRelation,
+					Object:   apiTestObject,
+				},
+			}).
+			Options(openfga.RequestOptions{
+				Headers: map[string]string{},
+			}).
+			Execute()
+
+		if err != nil {
+			t.Fatalf(apiRequestFailedMsg, err)
+		}
+
+		for header := range capturedHeaders {
+			if strings.HasPrefix(header, "X-") || header == apiDefaultHeaderName {
+				t.Errorf("Unexpected custom header found: %s", header)
+			}
+		}
+	})
+}
+
+func TestBatchCheckAPIMethodHeaderHandling(t *testing.T) {
+	t.Run("BatchCheckAPIWithCustomHeaders", func(t *testing.T) {
+		var capturedHeaders map[string]string
+		server := createAPITestServer(t, &capturedHeaders, `{"test-correlation-id": {"allowed": true}}`)
+		defer server.Close()
+
+		client := createAPITestClient(t, server.URL, map[string]string{
+			apiDefaultHeaderName: apiDefaultHeaderValue,
+		})
+
+		_, _, err := client.OpenFgaApi.BatchCheck(context.Background(), apiTestStoreId).
+			Body(openfga.BatchCheckRequest{
+				Checks: []openfga.BatchCheckItem{
+					{
+						TupleKey: openfga.CheckRequestTupleKey{
+							User:     apiTestUser,
+							Relation: apiTestRelation,
+							Object:   apiTestObject,
+						},
+						CorrelationId: "test-correlation-id",
+					},
+				},
+			}).
+			Options(openfga.RequestOptions{
+				Headers: map[string]string{
+					apiCustomHeaderName:  apiCustomHeaderValue,
+					apiDefaultHeaderName: apiOverriddenValue,
+				},
+			}).
+			Execute()
+
+		if err != nil {
+			t.Fatalf(apiRequestFailedMsg, err)
+		}
+
+		if capturedHeaders[apiCustomHeaderName] != apiCustomHeaderValue {
+			t.Errorf(apiExpectedCustomMsg, capturedHeaders[apiCustomHeaderName])
+		}
+
+		if capturedHeaders[apiDefaultHeaderName] != apiOverriddenValue {
+			t.Errorf(apiExpectedOverriddenMsg, capturedHeaders[apiDefaultHeaderName])
+		}
+	})
+}
+
+func TestWriteAPIMethodHeaderHandling(t *testing.T) {
+	t.Run("WriteAPIWithCustomHeaders", func(t *testing.T) {
+		var capturedHeaders map[string]string
+		server := createAPITestServer(t, &capturedHeaders, `{}`)
+		defer server.Close()
+
+		client := createAPITestClient(t, server.URL, map[string]string{
+			apiDefaultHeaderName: apiDefaultHeaderValue,
+		})
+
+		_, _, err := client.OpenFgaApi.Write(context.Background(), apiTestStoreId).
+			Body(openfga.WriteRequest{
+				Writes: &openfga.WriteRequestWrites{
+					TupleKeys: []openfga.TupleKey{
+						{
+							User:     apiTestUser,
+							Relation: apiTestRelation,
+							Object:   apiTestObject,
+						},
+					},
+				},
+			}).
+			Options(openfga.RequestOptions{
+				Headers: map[string]string{
+					apiCustomHeaderName:  apiCustomHeaderValue,
+					apiDefaultHeaderName: apiOverriddenValue,
+				},
+			}).
+			Execute()
+
+		if err != nil {
+			t.Fatalf(apiRequestFailedMsg, err)
+		}
+
+		if capturedHeaders[apiCustomHeaderName] != apiCustomHeaderValue {
+			t.Errorf(apiExpectedCustomMsg, capturedHeaders[apiCustomHeaderName])
+		}
+
+		if capturedHeaders[apiDefaultHeaderName] != apiOverriddenValue {
+			t.Errorf(apiExpectedOverriddenMsg, capturedHeaders[apiDefaultHeaderName])
+		}
+	})
+}
+
+func TestReadAPIMethodHeaderHandling(t *testing.T) {
+	t.Run("ReadAPIWithCustomHeaders", func(t *testing.T) {
+		var capturedHeaders map[string]string
+		server := createAPITestServer(t, &capturedHeaders, `{"tuples": []}`)
+		defer server.Close()
+
+		client := createAPITestClient(t, server.URL, map[string]string{
+			apiDefaultHeaderName: apiDefaultHeaderValue,
+		})
+
+		_, _, err := client.OpenFgaApi.Read(context.Background(), apiTestStoreId).
+			Body(openfga.ReadRequest{
+				TupleKey: &openfga.ReadRequestTupleKey{
+					User:     openfga.PtrString(apiTestUser),
+					Relation: openfga.PtrString(apiTestRelation),
+					Object:   openfga.PtrString(apiTestObject),
+				},
+			}).
+			Options(openfga.RequestOptions{
+				Headers: map[string]string{
+					apiCustomHeaderName:  apiCustomHeaderValue,
+					apiDefaultHeaderName: apiOverriddenValue,
+				},
+			}).
+			Execute()
+
+		if err != nil {
+			t.Fatalf(apiRequestFailedMsg, err)
+		}
+
+		if capturedHeaders[apiCustomHeaderName] != apiCustomHeaderValue {
+			t.Errorf(apiExpectedCustomMsg, capturedHeaders[apiCustomHeaderName])
+		}
+
+		if capturedHeaders[apiDefaultHeaderName] != apiOverriddenValue {
+			t.Errorf(apiExpectedOverriddenMsg, capturedHeaders[apiDefaultHeaderName])
+		}
+	})
+}
+
+func TestExpandAPIMethodHeaderHandling(t *testing.T) {
+	t.Run("ExpandAPIWithCustomHeaders", func(t *testing.T) {
+		var capturedHeaders map[string]string
+		server := createAPITestServer(t, &capturedHeaders, `{"tree": {"root": {"name": "document:roadmap#viewer"}}}`)
+		defer server.Close()
+
+		client := createAPITestClient(t, server.URL, map[string]string{
+			apiDefaultHeaderName: apiDefaultHeaderValue,
+		})
+
+		_, _, err := client.OpenFgaApi.Expand(context.Background(), apiTestStoreId).
+			Body(openfga.ExpandRequest{
+				TupleKey: openfga.ExpandRequestTupleKey{
+					Relation: apiTestRelation,
+					Object:   apiTestObject,
+				},
+			}).
+			Options(openfga.RequestOptions{
+				Headers: map[string]string{
+					apiCustomHeaderName:  apiCustomHeaderValue,
+					apiDefaultHeaderName: apiOverriddenValue,
+				},
+			}).
+			Execute()
+
+		if err != nil {
+			t.Fatalf(apiRequestFailedMsg, err)
+		}
+
+		if capturedHeaders[apiCustomHeaderName] != apiCustomHeaderValue {
+			t.Errorf(apiExpectedCustomMsg, capturedHeaders[apiCustomHeaderName])
+		}
+
+		if capturedHeaders[apiDefaultHeaderName] != apiOverriddenValue {
+			t.Errorf(apiExpectedOverriddenMsg, capturedHeaders[apiDefaultHeaderName])
+		}
+	})
+}
+
+func TestListObjectsAPIMethodHeaderHandling(t *testing.T) {
+	t.Run("ListObjectsAPIWithCustomHeaders", func(t *testing.T) {
+		var capturedHeaders map[string]string
+		server := createAPITestServer(t, &capturedHeaders, `{"objects": ["document:roadmap"]}`)
+		defer server.Close()
+
+		client := createAPITestClient(t, server.URL, map[string]string{
+			apiDefaultHeaderName: apiDefaultHeaderValue,
+		})
+
+		_, _, err := client.OpenFgaApi.ListObjects(context.Background(), apiTestStoreId).
+			Body(openfga.ListObjectsRequest{
+				User:     apiTestUser,
+				Relation: apiTestRelation,
+				Type:     "document",
+			}).
+			Options(openfga.RequestOptions{
+				Headers: map[string]string{
+					apiCustomHeaderName:  apiCustomHeaderValue,
+					apiDefaultHeaderName: apiOverriddenValue,
+				},
+			}).
+			Execute()
+
+		if err != nil {
+			t.Fatalf(apiRequestFailedMsg, err)
+		}
+
+		if capturedHeaders[apiCustomHeaderName] != apiCustomHeaderValue {
+			t.Errorf(apiExpectedCustomMsg, capturedHeaders[apiCustomHeaderName])
+		}
+
+		if capturedHeaders[apiDefaultHeaderName] != apiOverriddenValue {
+			t.Errorf(apiExpectedOverriddenMsg, capturedHeaders[apiDefaultHeaderName])
+		}
+	})
+}
+
+func TestListUsersAPIMethodHeaderHandling(t *testing.T) {
+	t.Run("ListUsersAPIWithCustomHeaders", func(t *testing.T) {
+		var capturedHeaders map[string]string
+		server := createAPITestServer(t, &capturedHeaders, `{"users": [{"object": {"type": "user", "id": "anne"}}]}`)
+		defer server.Close()
+
+		client := createAPITestClient(t, server.URL, map[string]string{
+			apiDefaultHeaderName: apiDefaultHeaderValue,
+		})
+
+		_, _, err := client.OpenFgaApi.ListUsers(context.Background(), apiTestStoreId).
+			Body(openfga.ListUsersRequest{
+				Object: openfga.FgaObject{
+					Type: "document",
+					Id:   "roadmap",
+				},
+				Relation: apiTestRelation,
+				UserFilters: []openfga.UserTypeFilter{
+					{Type: "user"},
+				},
+			}).
+			Options(openfga.RequestOptions{
+				Headers: map[string]string{
+					apiCustomHeaderName:  apiCustomHeaderValue,
+					apiDefaultHeaderName: apiOverriddenValue,
+				},
+			}).
+			Execute()
+
+		if err != nil {
+			t.Fatalf(apiRequestFailedMsg, err)
+		}
+
+		if capturedHeaders[apiCustomHeaderName] != apiCustomHeaderValue {
+			t.Errorf(apiExpectedCustomMsg, capturedHeaders[apiCustomHeaderName])
+		}
+
+		if capturedHeaders[apiDefaultHeaderName] != apiOverriddenValue {
+			t.Errorf(apiExpectedOverriddenMsg, capturedHeaders[apiDefaultHeaderName])
+		}
+	})
+}
+
+func TestStoreAPIMethodHeaderHandling(t *testing.T) {
+	t.Run("ListStoresAPIWithCustomHeaders", func(t *testing.T) {
+		var capturedHeaders map[string]string
+		server := createAPITestServer(t, &capturedHeaders, `{"stores": [{"id": "01H0H015178Y2V4CX10C2KGHF4", "name": "test"}]}`)
+		defer server.Close()
+
+		client := createAPITestClient(t, server.URL, map[string]string{
+			apiDefaultHeaderName: apiDefaultHeaderValue,
+		})
+
+		_, _, err := client.OpenFgaApi.ListStores(context.Background()).
+			Options(openfga.RequestOptions{
+				Headers: map[string]string{
+					apiCustomHeaderName:  apiCustomHeaderValue,
+					apiDefaultHeaderName: apiOverriddenValue,
+				},
+			}).
+			Execute()
+
+		if err != nil {
+			t.Fatalf(apiRequestFailedMsg, err)
+		}
+
+		if capturedHeaders[apiCustomHeaderName] != apiCustomHeaderValue {
+			t.Errorf(apiExpectedCustomMsg, capturedHeaders[apiCustomHeaderName])
+		}
+
+		if capturedHeaders[apiDefaultHeaderName] != apiOverriddenValue {
+			t.Errorf(apiExpectedOverriddenMsg, capturedHeaders[apiDefaultHeaderName])
+		}
+	})
+
+	t.Run("CreateStoreAPIWithCustomHeaders", func(t *testing.T) {
+		var capturedHeaders map[string]string
+		server := createAPITestServer(t, &capturedHeaders, `{"id": "01H0H015178Y2V4CX10C2KGHF4", "name": "test"}`)
+		defer server.Close()
+
+		client := createAPITestClient(t, server.URL, map[string]string{
+			apiDefaultHeaderName: apiDefaultHeaderValue,
+		})
+
+		_, _, err := client.OpenFgaApi.CreateStore(context.Background()).
+			Body(openfga.CreateStoreRequest{
+				Name: "test",
+			}).
+			Options(openfga.RequestOptions{
+				Headers: map[string]string{
+					apiCustomHeaderName:  apiCustomHeaderValue,
+					apiDefaultHeaderName: apiOverriddenValue,
+				},
+			}).
+			Execute()
+
+		if err != nil {
+			t.Fatalf(apiRequestFailedMsg, err)
+		}
+
+		if capturedHeaders[apiCustomHeaderName] != apiCustomHeaderValue {
+			t.Errorf(apiExpectedCustomMsg, capturedHeaders[apiCustomHeaderName])
+		}
+
+		if capturedHeaders[apiDefaultHeaderName] != apiOverriddenValue {
+			t.Errorf(apiExpectedOverriddenMsg, capturedHeaders[apiDefaultHeaderName])
+		}
+	})
+
+	t.Run("GetStoreAPIWithCustomHeaders", func(t *testing.T) {
+		var capturedHeaders map[string]string
+		server := createAPITestServer(t, &capturedHeaders, `{"id": "01H0H015178Y2V4CX10C2KGHF4", "name": "test"}`)
+		defer server.Close()
+
+		client := createAPITestClient(t, server.URL, map[string]string{
+			apiDefaultHeaderName: apiDefaultHeaderValue,
+		})
+
+		_, _, err := client.OpenFgaApi.GetStore(context.Background(), apiTestStoreId).
+			Options(openfga.RequestOptions{
+				Headers: map[string]string{
+					apiCustomHeaderName:  apiCustomHeaderValue,
+					apiDefaultHeaderName: apiOverriddenValue,
+				},
+			}).
+			Execute()
+
+		if err != nil {
+			t.Fatalf(apiRequestFailedMsg, err)
+		}
+
+		if capturedHeaders[apiCustomHeaderName] != apiCustomHeaderValue {
+			t.Errorf(apiExpectedCustomMsg, capturedHeaders[apiCustomHeaderName])
+		}
+
+		if capturedHeaders[apiDefaultHeaderName] != apiOverriddenValue {
+			t.Errorf(apiExpectedOverriddenMsg, capturedHeaders[apiDefaultHeaderName])
+		}
+	})
+
+	t.Run("DeleteStoreAPIWithCustomHeaders", func(t *testing.T) {
+		var capturedHeaders map[string]string
+		server := createAPITestServer(t, &capturedHeaders, `{}`)
+		defer server.Close()
+
+		client := createAPITestClient(t, server.URL, map[string]string{
+			apiDefaultHeaderName: apiDefaultHeaderValue,
+		})
+
+		_, err := client.OpenFgaApi.DeleteStore(context.Background(), apiTestStoreId).
+			Options(openfga.RequestOptions{
+				Headers: map[string]string{
+					apiCustomHeaderName:  apiCustomHeaderValue,
+					apiDefaultHeaderName: apiOverriddenValue,
+				},
+			}).
+			Execute()
+
+		if err != nil {
+			t.Fatalf(apiRequestFailedMsg, err)
+		}
+
+		if capturedHeaders[apiCustomHeaderName] != apiCustomHeaderValue {
+			t.Errorf(apiExpectedCustomMsg, capturedHeaders[apiCustomHeaderName])
+		}
+
+		if capturedHeaders[apiDefaultHeaderName] != apiOverriddenValue {
+			t.Errorf(apiExpectedOverriddenMsg, capturedHeaders[apiDefaultHeaderName])
+		}
+	})
+}
+
+func TestReadAuthorizationModelAPIMethodHeaderHandling(t *testing.T) {
+	t.Run("ReadAuthorizationModelAPIWithCustomHeaders", func(t *testing.T) {
+		var capturedHeaders map[string]string
+		server := createAPITestServer(t, &capturedHeaders, `{"authorization_model": {"id": "01H0H015178Y2V4CX10C2KGHF4", "schema_version": "1.1"}}`)
+		defer server.Close()
+
+		client := createAPITestClient(t, server.URL, map[string]string{
+			apiDefaultHeaderName: apiDefaultHeaderValue,
+		})
+
+		_, _, err := client.OpenFgaApi.ReadAuthorizationModel(context.Background(), apiTestStoreId, apiTestStoreId).
+			Options(openfga.RequestOptions{
+				Headers: map[string]string{
+					apiCustomHeaderName:  apiCustomHeaderValue,
+					apiDefaultHeaderName: apiOverriddenValue,
+				},
+			}).
+			Execute()
+
+		if err != nil {
+			t.Fatalf(apiRequestFailedMsg, err)
+		}
+
+		if capturedHeaders[apiCustomHeaderName] != apiCustomHeaderValue {
+			t.Errorf(apiExpectedCustomMsg, capturedHeaders[apiCustomHeaderName])
+		}
+
+		if capturedHeaders[apiDefaultHeaderName] != apiOverriddenValue {
+			t.Errorf(apiExpectedOverriddenMsg, capturedHeaders[apiDefaultHeaderName])
+		}
+	})
+}
+
+func TestWriteAuthorizationModelAPIMethodHeaderHandling(t *testing.T) {
+	t.Run("WriteAuthorizationModelAPIWithCustomHeaders", func(t *testing.T) {
+		var capturedHeaders map[string]string
+		server := createAPITestServer(t, &capturedHeaders, `{"authorization_model_id": "01H0H015178Y2V4CX10C2KGHF4"}`)
+		defer server.Close()
+
+		client := createAPITestClient(t, server.URL, map[string]string{
+			apiDefaultHeaderName: apiDefaultHeaderValue,
+		})
+
+		_, _, err := client.OpenFgaApi.WriteAuthorizationModel(context.Background(), apiTestStoreId).
+			Body(openfga.WriteAuthorizationModelRequest{
+				SchemaVersion: "1.1",
+				TypeDefinitions: []openfga.TypeDefinition{
+					{
+						Type: "user",
+					},
+					{
+						Type: "document",
+						Relations: &map[string]openfga.Userset{
+							"viewer": {},
+						},
+					},
+				},
+			}).
+			Options(openfga.RequestOptions{
+				Headers: map[string]string{
+					apiCustomHeaderName:  apiCustomHeaderValue,
+					apiDefaultHeaderName: apiOverriddenValue,
+				},
+			}).
+			Execute()
+
+		if err != nil {
+			t.Fatalf(apiRequestFailedMsg, err)
+		}
+
+		if capturedHeaders[apiCustomHeaderName] != apiCustomHeaderValue {
+			t.Errorf(apiExpectedCustomMsg, capturedHeaders[apiCustomHeaderName])
+		}
+
+		if capturedHeaders[apiDefaultHeaderName] != apiOverriddenValue {
+			t.Errorf(apiExpectedOverriddenMsg, capturedHeaders[apiDefaultHeaderName])
+		}
+	})
+}
+
+func TestReadChangesAPIMethodHeaderHandling(t *testing.T) {
+	t.Run("ReadChangesAPIWithCustomHeaders", func(t *testing.T) {
+		var capturedHeaders map[string]string
+		server := createAPITestServer(t, &capturedHeaders, `{"changes": [], "continuation_token": ""}`)
+		defer server.Close()
+
+		client := createAPITestClient(t, server.URL, map[string]string{
+			apiDefaultHeaderName: apiDefaultHeaderValue,
+		})
+
+		_, _, err := client.OpenFgaApi.ReadChanges(context.Background(), apiTestStoreId).
+			Type_("document").
+			Options(openfga.RequestOptions{
+				Headers: map[string]string{
+					apiCustomHeaderName:  apiCustomHeaderValue,
+					apiDefaultHeaderName: apiOverriddenValue,
+				},
+			}).
+			Execute()
+
+		if err != nil {
+			t.Fatalf(apiRequestFailedMsg, err)
+		}
+
+		if capturedHeaders[apiCustomHeaderName] != apiCustomHeaderValue {
+			t.Errorf(apiExpectedCustomMsg, capturedHeaders[apiCustomHeaderName])
+		}
+
+		if capturedHeaders[apiDefaultHeaderName] != apiOverriddenValue {
+			t.Errorf(apiExpectedOverriddenMsg, capturedHeaders[apiDefaultHeaderName])
+		}
+	})
+}
+
+func TestAssertionsAPIMethodHeaderHandling(t *testing.T) {
+	t.Run("ReadAssertionsAPIWithCustomHeaders", func(t *testing.T) {
+		var capturedHeaders map[string]string
+		server := createAPITestServer(t, &capturedHeaders, `{"assertions": []}`)
+		defer server.Close()
+
+		client := createAPITestClient(t, server.URL, map[string]string{
+			apiDefaultHeaderName: apiDefaultHeaderValue,
+		})
+
+		_, _, err := client.OpenFgaApi.ReadAssertions(context.Background(), apiTestStoreId, apiTestStoreId).
+			Options(openfga.RequestOptions{
+				Headers: map[string]string{
+					apiCustomHeaderName:  apiCustomHeaderValue,
+					apiDefaultHeaderName: apiOverriddenValue,
+				},
+			}).
+			Execute()
+
+		if err != nil {
+			t.Fatalf(apiRequestFailedMsg, err)
+		}
+
+		if capturedHeaders[apiCustomHeaderName] != apiCustomHeaderValue {
+			t.Errorf(apiExpectedCustomMsg, capturedHeaders[apiCustomHeaderName])
+		}
+
+		if capturedHeaders[apiDefaultHeaderName] != apiOverriddenValue {
+			t.Errorf(apiExpectedOverriddenMsg, capturedHeaders[apiDefaultHeaderName])
+		}
+	})
+
+	t.Run("WriteAssertionsAPIWithCustomHeaders", func(t *testing.T) {
+		var capturedHeaders map[string]string
+		server := createAPITestServer(t, &capturedHeaders, `{}`)
+		defer server.Close()
+
+		client := createAPITestClient(t, server.URL, map[string]string{
+			apiDefaultHeaderName: apiDefaultHeaderValue,
+		})
+
+		_, err := client.OpenFgaApi.WriteAssertions(context.Background(), apiTestStoreId, apiTestStoreId).
+			Body(openfga.WriteAssertionsRequest{
+				Assertions: []openfga.Assertion{
+					{
+						TupleKey: openfga.AssertionTupleKey{
+							User:     apiTestUser,
+							Relation: apiTestRelation,
+							Object:   apiTestObject,
+						},
+						Expectation: true,
+					},
+				},
+			}).
+			Options(openfga.RequestOptions{
+				Headers: map[string]string{
+					apiCustomHeaderName:  apiCustomHeaderValue,
+					apiDefaultHeaderName: apiOverriddenValue,
+				},
+			}).
+			Execute()
+
+		if err != nil {
+			t.Fatalf(apiRequestFailedMsg, err)
+		}
+
+		if capturedHeaders[apiCustomHeaderName] != apiCustomHeaderValue {
+			t.Errorf(apiExpectedCustomMsg, capturedHeaders[apiCustomHeaderName])
+		}
+
+		if capturedHeaders[apiDefaultHeaderName] != apiOverriddenValue {
+			t.Errorf(apiExpectedOverriddenMsg, capturedHeaders[apiDefaultHeaderName])
+		}
+	})
+}

--- a/api_open_fga.go
+++ b/api_open_fga.go
@@ -32,6 +32,12 @@ var (
 	_ context.Context
 )
 
+type RequestOptions struct {
+	MaxRetry    *int              `json:"max_retry,omitempty"`
+	MinWaitInMs *int              `json:"min_wait_in_ms,omitempty"`
+	Headers     map[string]string `json:"headers,omitempty"`
+}
+
 type OpenFgaApi interface {
 
 	/*
@@ -900,10 +906,16 @@ type ApiBatchCheckRequest struct {
 	ApiService OpenFgaApi
 	storeId    string
 	body       *BatchCheckRequest
+	options    RequestOptions
 }
 
 func (r ApiBatchCheckRequest) Body(body BatchCheckRequest) ApiBatchCheckRequest {
 	r.body = &body
+	return r
+}
+
+func (r ApiBatchCheckRequest) Options(options RequestOptions) ApiBatchCheckRequest {
+	r.options = options
 	return r
 }
 
@@ -1029,6 +1041,11 @@ func (a *OpenFgaApiService) BatchCheckExecute(r ApiBatchCheckRequest) (BatchChec
 	// body params
 	requestBody = r.body
 
+	// if any override headers were in the options, set them now
+	for header, val := range r.options.Headers {
+		localVarHeaderParams[header] = val
+	}
+
 	retryParams := a.client.cfg.RetryParams
 	for i := 0; i < retryParams.MaxRetry+1; i++ {
 		req, err := a.client.prepareRequest(r.ctx, path, httpMethod, requestBody, localVarHeaderParams, localVarQueryParams)
@@ -1136,10 +1153,16 @@ type ApiCheckRequest struct {
 	ApiService OpenFgaApi
 	storeId    string
 	body       *CheckRequest
+	options    RequestOptions
 }
 
 func (r ApiCheckRequest) Body(body CheckRequest) ApiCheckRequest {
 	r.body = &body
+	return r
+}
+
+func (r ApiCheckRequest) Options(options RequestOptions) ApiCheckRequest {
+	r.options = options
 	return r
 }
 
@@ -1349,6 +1372,11 @@ func (a *OpenFgaApiService) CheckExecute(r ApiCheckRequest) (CheckResponse, *htt
 	// body params
 	requestBody = r.body
 
+	// if any override headers were in the options, set them now
+	for header, val := range r.options.Headers {
+		localVarHeaderParams[header] = val
+	}
+
 	retryParams := a.client.cfg.RetryParams
 	for i := 0; i < retryParams.MaxRetry+1; i++ {
 		req, err := a.client.prepareRequest(r.ctx, path, httpMethod, requestBody, localVarHeaderParams, localVarQueryParams)
@@ -1455,10 +1483,16 @@ type ApiCreateStoreRequest struct {
 	ctx        context.Context
 	ApiService OpenFgaApi
 	body       *CreateStoreRequest
+	options    RequestOptions
 }
 
 func (r ApiCreateStoreRequest) Body(body CreateStoreRequest) ApiCreateStoreRequest {
 	r.body = &body
+	return r
+}
+
+func (r ApiCreateStoreRequest) Options(options RequestOptions) ApiCreateStoreRequest {
+	r.options = options
 	return r
 }
 
@@ -1521,6 +1555,11 @@ func (a *OpenFgaApiService) CreateStoreExecute(r ApiCreateStoreRequest) (CreateS
 	}
 	// body params
 	requestBody = r.body
+
+	// if any override headers were in the options, set them now
+	for header, val := range r.options.Headers {
+		localVarHeaderParams[header] = val
+	}
 
 	retryParams := a.client.cfg.RetryParams
 	for i := 0; i < retryParams.MaxRetry+1; i++ {
@@ -1627,6 +1666,12 @@ type ApiDeleteStoreRequest struct {
 	ctx        context.Context
 	ApiService OpenFgaApi
 	storeId    string
+	options    RequestOptions
+}
+
+func (r ApiDeleteStoreRequest) Options(options RequestOptions) ApiDeleteStoreRequest {
+	r.options = options
+	return r
 }
 
 func (r ApiDeleteStoreRequest) Execute() (*http.Response, error) {
@@ -1687,6 +1732,11 @@ func (a *OpenFgaApiService) DeleteStoreExecute(r ApiDeleteStoreRequest) (*http.R
 	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+
+	// if any override headers were in the options, set them now
+	for header, val := range r.options.Headers {
+		localVarHeaderParams[header] = val
 	}
 
 	retryParams := a.client.cfg.RetryParams
@@ -1787,10 +1837,16 @@ type ApiExpandRequest struct {
 	ApiService OpenFgaApi
 	storeId    string
 	body       *ExpandRequest
+	options    RequestOptions
 }
 
 func (r ApiExpandRequest) Body(body ExpandRequest) ApiExpandRequest {
 	r.body = &body
+	return r
+}
+
+func (r ApiExpandRequest) Options(options RequestOptions) ApiExpandRequest {
+	r.options = options
 	return r
 }
 
@@ -2038,6 +2094,11 @@ func (a *OpenFgaApiService) ExpandExecute(r ApiExpandRequest) (ExpandResponse, *
 	// body params
 	requestBody = r.body
 
+	// if any override headers were in the options, set them now
+	for header, val := range r.options.Headers {
+		localVarHeaderParams[header] = val
+	}
+
 	retryParams := a.client.cfg.RetryParams
 	for i := 0; i < retryParams.MaxRetry+1; i++ {
 		req, err := a.client.prepareRequest(r.ctx, path, httpMethod, requestBody, localVarHeaderParams, localVarQueryParams)
@@ -2144,6 +2205,12 @@ type ApiGetStoreRequest struct {
 	ctx        context.Context
 	ApiService OpenFgaApi
 	storeId    string
+	options    RequestOptions
+}
+
+func (r ApiGetStoreRequest) Options(options RequestOptions) ApiGetStoreRequest {
+	r.options = options
+	return r
 }
 
 func (r ApiGetStoreRequest) Execute() (GetStoreResponse, *http.Response, error) {
@@ -2206,6 +2273,11 @@ func (a *OpenFgaApiService) GetStoreExecute(r ApiGetStoreRequest) (GetStoreRespo
 	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+
+	// if any override headers were in the options, set them now
+	for header, val := range r.options.Headers {
+		localVarHeaderParams[header] = val
 	}
 
 	retryParams := a.client.cfg.RetryParams
@@ -2315,10 +2387,16 @@ type ApiListObjectsRequest struct {
 	ApiService OpenFgaApi
 	storeId    string
 	body       *ListObjectsRequest
+	options    RequestOptions
 }
 
 func (r ApiListObjectsRequest) Body(body ListObjectsRequest) ApiListObjectsRequest {
 	r.body = &body
+	return r
+}
+
+func (r ApiListObjectsRequest) Options(options RequestOptions) ApiListObjectsRequest {
+	r.options = options
 	return r
 }
 
@@ -2397,6 +2475,11 @@ func (a *OpenFgaApiService) ListObjectsExecute(r ApiListObjectsRequest) (ListObj
 	}
 	// body params
 	requestBody = r.body
+
+	// if any override headers were in the options, set them now
+	for header, val := range r.options.Headers {
+		localVarHeaderParams[header] = val
+	}
 
 	retryParams := a.client.cfg.RetryParams
 	for i := 0; i < retryParams.MaxRetry+1; i++ {
@@ -2506,6 +2589,7 @@ type ApiListStoresRequest struct {
 	pageSize          *int32
 	continuationToken *string
 	name              *string
+	options           RequestOptions
 }
 
 func (r ApiListStoresRequest) PageSize(pageSize int32) ApiListStoresRequest {
@@ -2518,6 +2602,11 @@ func (r ApiListStoresRequest) ContinuationToken(continuationToken string) ApiLis
 }
 func (r ApiListStoresRequest) Name(name string) ApiListStoresRequest {
 	r.name = &name
+	return r
+}
+
+func (r ApiListStoresRequest) Options(options RequestOptions) ApiListStoresRequest {
+	r.options = options
 	return r
 }
 
@@ -2586,6 +2675,11 @@ func (a *OpenFgaApiService) ListStoresExecute(r ApiListStoresRequest) (ListStore
 	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+
+	// if any override headers were in the options, set them now
+	for header, val := range r.options.Headers {
+		localVarHeaderParams[header] = val
 	}
 
 	retryParams := a.client.cfg.RetryParams
@@ -2694,10 +2788,16 @@ type ApiListUsersRequest struct {
 	ApiService OpenFgaApi
 	storeId    string
 	body       *ListUsersRequest
+	options    RequestOptions
 }
 
 func (r ApiListUsersRequest) Body(body ListUsersRequest) ApiListUsersRequest {
 	r.body = &body
+	return r
+}
+
+func (r ApiListUsersRequest) Options(options RequestOptions) ApiListUsersRequest {
+	r.options = options
 	return r
 }
 
@@ -2777,6 +2877,11 @@ func (a *OpenFgaApiService) ListUsersExecute(r ApiListUsersRequest) (ListUsersRe
 	}
 	// body params
 	requestBody = r.body
+
+	// if any override headers were in the options, set them now
+	for header, val := range r.options.Headers {
+		localVarHeaderParams[header] = val
+	}
 
 	retryParams := a.client.cfg.RetryParams
 	for i := 0; i < retryParams.MaxRetry+1; i++ {
@@ -2885,10 +2990,16 @@ type ApiReadRequest struct {
 	ApiService OpenFgaApi
 	storeId    string
 	body       *ReadRequest
+	options    RequestOptions
 }
 
 func (r ApiReadRequest) Body(body ReadRequest) ApiReadRequest {
 	r.body = &body
+	return r
+}
+
+func (r ApiReadRequest) Options(options RequestOptions) ApiReadRequest {
+	r.options = options
 	return r
 }
 
@@ -3070,6 +3181,11 @@ func (a *OpenFgaApiService) ReadExecute(r ApiReadRequest) (ReadResponse, *http.R
 	// body params
 	requestBody = r.body
 
+	// if any override headers were in the options, set them now
+	for header, val := range r.options.Headers {
+		localVarHeaderParams[header] = val
+	}
+
 	retryParams := a.client.cfg.RetryParams
 	for i := 0; i < retryParams.MaxRetry+1; i++ {
 		req, err := a.client.prepareRequest(r.ctx, path, httpMethod, requestBody, localVarHeaderParams, localVarQueryParams)
@@ -3177,6 +3293,12 @@ type ApiReadAssertionsRequest struct {
 	ApiService           OpenFgaApi
 	storeId              string
 	authorizationModelId string
+	options              RequestOptions
+}
+
+func (r ApiReadAssertionsRequest) Options(options RequestOptions) ApiReadAssertionsRequest {
+	r.options = options
+	return r
 }
 
 func (r ApiReadAssertionsRequest) Execute() (ReadAssertionsResponse, *http.Response, error) {
@@ -3246,6 +3368,11 @@ func (a *OpenFgaApiService) ReadAssertionsExecute(r ApiReadAssertionsRequest) (R
 	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+
+	// if any override headers were in the options, set them now
+	for header, val := range r.options.Headers {
+		localVarHeaderParams[header] = val
 	}
 
 	retryParams := a.client.cfg.RetryParams
@@ -3355,6 +3482,12 @@ type ApiReadAuthorizationModelRequest struct {
 	ApiService OpenFgaApi
 	storeId    string
 	id         string
+	options    RequestOptions
+}
+
+func (r ApiReadAuthorizationModelRequest) Options(options RequestOptions) ApiReadAuthorizationModelRequest {
+	r.options = options
+	return r
 }
 
 func (r ApiReadAuthorizationModelRequest) Execute() (ReadAuthorizationModelResponse, *http.Response, error) {
@@ -3469,6 +3602,11 @@ func (a *OpenFgaApiService) ReadAuthorizationModelExecute(r ApiReadAuthorization
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 
+	// if any override headers were in the options, set them now
+	for header, val := range r.options.Headers {
+		localVarHeaderParams[header] = val
+	}
+
 	retryParams := a.client.cfg.RetryParams
 	for i := 0; i < retryParams.MaxRetry+1; i++ {
 		req, err := a.client.prepareRequest(r.ctx, path, httpMethod, requestBody, localVarHeaderParams, localVarQueryParams)
@@ -3577,6 +3715,7 @@ type ApiReadAuthorizationModelsRequest struct {
 	storeId           string
 	pageSize          *int32
 	continuationToken *string
+	options           RequestOptions
 }
 
 func (r ApiReadAuthorizationModelsRequest) PageSize(pageSize int32) ApiReadAuthorizationModelsRequest {
@@ -3585,6 +3724,11 @@ func (r ApiReadAuthorizationModelsRequest) PageSize(pageSize int32) ApiReadAutho
 }
 func (r ApiReadAuthorizationModelsRequest) ContinuationToken(continuationToken string) ApiReadAuthorizationModelsRequest {
 	r.continuationToken = &continuationToken
+	return r
+}
+
+func (r ApiReadAuthorizationModelsRequest) Options(options RequestOptions) ApiReadAuthorizationModelsRequest {
+	r.options = options
 	return r
 }
 
@@ -3697,6 +3841,11 @@ func (a *OpenFgaApiService) ReadAuthorizationModelsExecute(r ApiReadAuthorizatio
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 
+	// if any override headers were in the options, set them now
+	for header, val := range r.options.Headers {
+		localVarHeaderParams[header] = val
+	}
+
 	retryParams := a.client.cfg.RetryParams
 	for i := 0; i < retryParams.MaxRetry+1; i++ {
 		req, err := a.client.prepareRequest(r.ctx, path, httpMethod, requestBody, localVarHeaderParams, localVarQueryParams)
@@ -3807,6 +3956,7 @@ type ApiReadChangesRequest struct {
 	pageSize          *int32
 	continuationToken *string
 	startTime         *time.Time
+	options           RequestOptions
 }
 
 func (r ApiReadChangesRequest) Type_(type_ string) ApiReadChangesRequest {
@@ -3823,6 +3973,11 @@ func (r ApiReadChangesRequest) ContinuationToken(continuationToken string) ApiRe
 }
 func (r ApiReadChangesRequest) StartTime(startTime time.Time) ApiReadChangesRequest {
 	r.startTime = &startTime
+	return r
+}
+
+func (r ApiReadChangesRequest) Options(options RequestOptions) ApiReadChangesRequest {
+	r.options = options
 	return r
 }
 
@@ -3903,6 +4058,11 @@ func (a *OpenFgaApiService) ReadChangesExecute(r ApiReadChangesRequest) (ReadCha
 	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+
+	// if any override headers were in the options, set them now
+	for header, val := range r.options.Headers {
+		localVarHeaderParams[header] = val
 	}
 
 	retryParams := a.client.cfg.RetryParams
@@ -4012,10 +4172,16 @@ type ApiWriteRequest struct {
 	ApiService OpenFgaApi
 	storeId    string
 	body       *WriteRequest
+	options    RequestOptions
 }
 
 func (r ApiWriteRequest) Body(body WriteRequest) ApiWriteRequest {
 	r.body = &body
+	return r
+}
+
+func (r ApiWriteRequest) Options(options RequestOptions) ApiWriteRequest {
+	r.options = options
 	return r
 }
 
@@ -4128,6 +4294,11 @@ func (a *OpenFgaApiService) WriteExecute(r ApiWriteRequest) (map[string]interfac
 	// body params
 	requestBody = r.body
 
+	// if any override headers were in the options, set them now
+	for header, val := range r.options.Headers {
+		localVarHeaderParams[header] = val
+	}
+
 	retryParams := a.client.cfg.RetryParams
 	for i := 0; i < retryParams.MaxRetry+1; i++ {
 		req, err := a.client.prepareRequest(r.ctx, path, httpMethod, requestBody, localVarHeaderParams, localVarQueryParams)
@@ -4236,10 +4407,16 @@ type ApiWriteAssertionsRequest struct {
 	storeId              string
 	authorizationModelId string
 	body                 *WriteAssertionsRequest
+	options              RequestOptions
 }
 
 func (r ApiWriteAssertionsRequest) Body(body WriteAssertionsRequest) ApiWriteAssertionsRequest {
 	r.body = &body
+	return r
+}
+
+func (r ApiWriteAssertionsRequest) Options(options RequestOptions) ApiWriteAssertionsRequest {
+	r.options = options
 	return r
 }
 
@@ -4314,6 +4491,11 @@ func (a *OpenFgaApiService) WriteAssertionsExecute(r ApiWriteAssertionsRequest) 
 	}
 	// body params
 	requestBody = r.body
+
+	// if any override headers were in the options, set them now
+	for header, val := range r.options.Headers {
+		localVarHeaderParams[header] = val
+	}
 
 	retryParams := a.client.cfg.RetryParams
 	for i := 0; i < retryParams.MaxRetry+1; i++ {
@@ -4413,10 +4595,16 @@ type ApiWriteAuthorizationModelRequest struct {
 	ApiService OpenFgaApi
 	storeId    string
 	body       *WriteAuthorizationModelRequest
+	options    RequestOptions
 }
 
 func (r ApiWriteAuthorizationModelRequest) Body(body WriteAuthorizationModelRequest) ApiWriteAuthorizationModelRequest {
 	r.body = &body
+	return r
+}
+
+func (r ApiWriteAuthorizationModelRequest) Options(options RequestOptions) ApiWriteAuthorizationModelRequest {
+	r.options = options
 	return r
 }
 
@@ -4531,6 +4719,11 @@ func (a *OpenFgaApiService) WriteAuthorizationModelExecute(r ApiWriteAuthorizati
 	}
 	// body params
 	requestBody = r.body
+
+	// if any override headers were in the options, set them now
+	for header, val := range r.options.Headers {
+		localVarHeaderParams[header] = val
+	}
 
 	retryParams := a.client.cfg.RetryParams
 	for i := 0; i < retryParams.MaxRetry+1; i++ {

--- a/client/client.go
+++ b/client/client.go
@@ -118,17 +118,14 @@ func NewSdkClient(cfg *ClientConfiguration) (*OpenFgaClient, error) {
 	}, nil
 }
 
-type ClientRequestOptions struct {
-	MaxRetry    *int `json:"max_retry,omitempty"`
-	MinWaitInMs *int `json:"min_wait_in_ms,omitempty"`
-}
+type RequestOptions = fgaSdk.RequestOptions
 
 type AuthorizationModelIdOptions struct {
 	AuthorizationModelId *string `json:"authorization_model_id,omitempty"`
 }
 
 type ClientRequestOptionsWithAuthZModelId struct {
-	ClientRequestOptions
+	RequestOptions
 	AuthorizationModelIdOptions
 }
 
@@ -156,6 +153,8 @@ type ClientBatchCheckRequest struct {
 
 // BatchCheckOptions represents options for server-side batch check operations
 type BatchCheckOptions struct {
+	RequestOptions
+
 	AuthorizationModelId *string                       `json:"authorization_model_id,omitempty"`
 	StoreId              *string                       `json:"store_id,omitempty"`
 	MaxParallelRequests  *int32                        `json:"max_parallel_requests,omitempty"`
@@ -578,6 +577,8 @@ type SdkClientListStoresRequestInterface interface {
 }
 
 type ClientListStoresOptions struct {
+	RequestOptions
+
 	PageSize          *int32  `json:"page_size,omitempty"`
 	ContinuationToken *string `json:"continuation_token,omitempty"`
 	Name              *string `json:"name,omitempty"`
@@ -606,6 +607,7 @@ func (client *OpenFgaClient) ListStoresExecute(request SdkClientListStoresReques
 	req := client.OpenFgaApi.ListStores(request.GetContext())
 	options := request.GetOptions()
 	if options != nil {
+		req = req.Options(options.RequestOptions)
 		if options.PageSize != nil {
 			req = req.PageSize(*options.PageSize)
 		}
@@ -616,6 +618,7 @@ func (client *OpenFgaClient) ListStoresExecute(request SdkClientListStoresReques
 			req = req.Name(*options.Name)
 		}
 	}
+
 	data, _, err := req.Execute()
 	if err != nil {
 		return nil, err
@@ -654,6 +657,7 @@ type ClientCreateStoreRequest struct {
 }
 
 type ClientCreateStoreOptions struct {
+	RequestOptions
 }
 
 type ClientCreateStoreResponse = fgaSdk.CreateStoreResponse
@@ -685,9 +689,20 @@ func (request *SdkClientCreateStoreRequest) GetBody() *ClientCreateStoreRequest 
 }
 
 func (client *OpenFgaClient) CreateStoreExecute(request SdkClientCreateStoreRequestInterface) (*ClientCreateStoreResponse, error) {
-	data, _, err := client.OpenFgaApi.CreateStore(request.GetContext()).Body(fgaSdk.CreateStoreRequest{
+	requestOptions := RequestOptions{}
+	if request.GetOptions() != nil {
+		requestOptions = request.GetOptions().RequestOptions
+	}
+
+	requestBody := fgaSdk.CreateStoreRequest{
 		Name: request.GetBody().Name,
-	}).Execute()
+	}
+
+	data, _, err := client.OpenFgaApi.
+		CreateStore(request.GetContext()).
+		Body(requestBody).
+		Options(requestOptions).
+		Execute()
 	if err != nil {
 		return nil, err
 	}
@@ -719,6 +734,8 @@ type SdkClientGetStoreRequestInterface interface {
 }
 
 type ClientGetStoreOptions struct {
+	RequestOptions
+
 	StoreId *string `json:"store_id,omitempty"`
 }
 
@@ -753,7 +770,16 @@ func (client *OpenFgaClient) GetStoreExecute(request SdkClientGetStoreRequestInt
 	if err != nil {
 		return nil, err
 	}
-	data, _, err := client.OpenFgaApi.GetStore(request.GetContext(), *storeId).Execute()
+
+	requestOptions := RequestOptions{}
+	if request.GetOptions() != nil {
+		requestOptions = request.GetOptions().RequestOptions
+	}
+
+	data, _, err := client.OpenFgaApi.
+		GetStore(request.GetContext(), *storeId).
+		Options(requestOptions).
+		Execute()
 	if err != nil {
 		return nil, err
 	}
@@ -785,6 +811,8 @@ type SdkClientDeleteStoreRequestInterface interface {
 }
 
 type ClientDeleteStoreOptions struct {
+	RequestOptions
+
 	StoreId *string `json:"store_id,omitempty"`
 }
 
@@ -819,7 +847,16 @@ func (client *OpenFgaClient) DeleteStoreExecute(request SdkClientDeleteStoreRequ
 	if err != nil {
 		return nil, err
 	}
-	_, err = client.OpenFgaApi.DeleteStore(request.GetContext(), *storeId).Execute()
+
+	requestOptions := RequestOptions{}
+	if request.GetOptions() != nil {
+		requestOptions = request.GetOptions().RequestOptions
+	}
+
+	_, err = client.OpenFgaApi.
+		DeleteStore(request.GetContext(), *storeId).
+		Options(requestOptions).
+		Execute()
 	if err != nil {
 		return nil, err
 	}
@@ -853,6 +890,8 @@ type SdkClientReadAuthorizationModelsRequestInterface interface {
 }
 
 type ClientReadAuthorizationModelsOptions struct {
+	RequestOptions
+
 	PageSize          *int32  `json:"page_size,omitempty"`
 	ContinuationToken *string `json:"continuation_token,omitempty"`
 	StoreId           *string `json:"store_id,omitempty"`
@@ -896,7 +935,15 @@ func (client *OpenFgaClient) ReadAuthorizationModelsExecute(request SdkClientRea
 		return nil, err
 	}
 
-	req := client.OpenFgaApi.ReadAuthorizationModels(request.GetContext(), *storeId)
+	requestOptions := RequestOptions{}
+	if request.GetOptions() != nil {
+		requestOptions = request.GetOptions().RequestOptions
+	}
+
+	req := client.OpenFgaApi.
+		ReadAuthorizationModels(request.GetContext(), *storeId).
+		Options(requestOptions)
+
 	pageSize := getPageSizeFromRequest(&pagingOpts)
 	if pageSize != nil {
 		req = req.PageSize(*pageSize)
@@ -942,6 +989,8 @@ type SdkClientWriteAuthorizationModelRequestInterface interface {
 type ClientWriteAuthorizationModelRequest = fgaSdk.WriteAuthorizationModelRequest
 
 type ClientWriteAuthorizationModelOptions struct {
+	RequestOptions
+
 	StoreId *string `json:"store_id,omitempty"`
 }
 
@@ -985,7 +1034,17 @@ func (client *OpenFgaClient) WriteAuthorizationModelExecute(request SdkClientWri
 	if err != nil {
 		return nil, err
 	}
-	data, _, err := client.OpenFgaApi.WriteAuthorizationModel(request.GetContext(), *storeId).Body(*request.GetBody()).Execute()
+
+	requestOptions := RequestOptions{}
+	if request.GetOptions() != nil {
+		requestOptions = request.GetOptions().RequestOptions
+	}
+
+	data, _, err := client.OpenFgaApi.
+		WriteAuthorizationModel(request.GetContext(), *storeId).
+		Body(*request.GetBody()).
+		Options(requestOptions).
+		Execute()
 	if err != nil {
 		return nil, err
 	}
@@ -1024,6 +1083,8 @@ type ClientReadAuthorizationModelRequest struct {
 }
 
 type ClientReadAuthorizationModelOptions struct {
+	RequestOptions
+
 	AuthorizationModelId *string `json:"authorization_model_id,omitempty"`
 	StoreId              *string `json:"store_id,omitempty"`
 }
@@ -1082,8 +1143,16 @@ func (client *OpenFgaClient) ReadAuthorizationModelExecute(request SdkClientRead
 	if err != nil {
 		return nil, err
 	}
-	data, _, err := client.OpenFgaApi.ReadAuthorizationModel(request.GetContext(), *storeId, *authorizationModelId).Execute()
 
+	requestOptions := RequestOptions{}
+	if request.GetOptions() != nil {
+		requestOptions = request.GetOptions().RequestOptions
+	}
+
+	data, _, err := client.OpenFgaApi.
+		ReadAuthorizationModel(request.GetContext(), *storeId, *authorizationModelId).
+		Options(requestOptions).
+		Execute()
 	if err != nil {
 		return nil, err
 	}
@@ -1115,6 +1184,8 @@ type SdkClientReadLatestAuthorizationModelRequestInterface interface {
 }
 
 type ClientReadLatestAuthorizationModelOptions struct {
+	RequestOptions
+
 	StoreId *string `json:"store_id,omitempty"`
 }
 
@@ -1155,6 +1226,7 @@ func (client *OpenFgaClient) ReadLatestAuthorizationModelExecute(request SdkClie
 	}
 	if request.GetOptions() != nil {
 		opts.StoreId = request.GetOptions().StoreId
+		opts.RequestOptions = request.GetOptions().RequestOptions
 	}
 	req := client.ReadAuthorizationModels(request.GetContext()).Options(opts)
 
@@ -1203,6 +1275,8 @@ type ClientReadChangesRequest struct {
 }
 
 type ClientReadChangesOptions struct {
+	RequestOptions
+
 	PageSize          *int32  `json:"page_size,omitempty"`
 	ContinuationToken *string `json:"continuation_token,omitempty"`
 	StoreId           *string `json:"store_id"`
@@ -1252,7 +1326,9 @@ func (request *SdkClientReadChangesRequest) GetOptions() *ClientReadChangesOptio
 
 func (client *OpenFgaClient) ReadChangesExecute(request SdkClientReadChangesRequestInterface) (*ClientReadChangesResponse, error) {
 	pagingOpts := ClientPaginationOptions{}
+	requestOptions := RequestOptions{}
 	if request.GetOptions() != nil {
+		requestOptions = request.GetOptions().RequestOptions
 		pagingOpts.PageSize = request.GetOptions().PageSize
 		pagingOpts.ContinuationToken = request.GetOptions().ContinuationToken
 	}
@@ -1262,7 +1338,9 @@ func (client *OpenFgaClient) ReadChangesExecute(request SdkClientReadChangesRequ
 		return nil, err
 	}
 
-	req := client.OpenFgaApi.ReadChanges(request.GetContext(), *storeId)
+	req := client.OpenFgaApi.
+		ReadChanges(request.GetContext(), *storeId).
+		Options(requestOptions)
 	pageSize := getPageSizeFromRequest(&pagingOpts)
 	if pageSize != nil {
 		req = req.PageSize(*pageSize)
@@ -1313,6 +1391,8 @@ type ClientReadRequest struct {
 }
 
 type ClientReadOptions struct {
+	RequestOptions
+
 	PageSize          *int32                        `json:"page_size,omitempty"`
 	ContinuationToken *string                       `json:"continuation_token,omitempty"`
 	StoreId           *string                       `json:"store_id,omitempty"`
@@ -1363,8 +1443,10 @@ func (request *SdkClientReadRequest) GetOptions() *ClientReadOptions {
 
 func (client *OpenFgaClient) ReadExecute(request SdkClientReadRequestInterface) (*ClientReadResponse, error) {
 	pagingOpts := ClientPaginationOptions{}
+	requestOptions := RequestOptions{}
 	var consistency *fgaSdk.ConsistencyPreference
 	if request.GetOptions() != nil {
+		requestOptions = request.GetOptions().RequestOptions
 		pagingOpts.PageSize = request.GetOptions().PageSize
 		pagingOpts.ContinuationToken = request.GetOptions().ContinuationToken
 		consistency = request.GetOptions().Consistency
@@ -1386,7 +1468,12 @@ func (client *OpenFgaClient) ReadExecute(request SdkClientReadRequestInterface) 
 	if err != nil {
 		return nil, err
 	}
-	data, _, err := client.OpenFgaApi.Read(request.GetContext(), *storeId).Body(body).Execute()
+
+	data, _, err := client.OpenFgaApi.
+		Read(request.GetContext(), *storeId).
+		Body(body).
+		Options(requestOptions).
+		Execute()
 	if err != nil {
 		return nil, err
 	}
@@ -1429,6 +1516,8 @@ type TransactionOptions struct {
 }
 
 type ClientWriteOptions struct {
+	RequestOptions
+
 	AuthorizationModelId *string             `json:"authorization_model_id,omitempty"`
 	StoreId              *string             `json:"store_id,omitempty"`
 	Transaction          *TransactionOptions `json:"transaction_options,omitempty"`
@@ -1546,6 +1635,10 @@ func (client *OpenFgaClient) WriteExecute(request SdkClientWriteRequestInterface
 		Writes:  []ClientWriteRequestWriteResponse{},
 		Deletes: []ClientWriteRequestDeleteResponse{},
 	}
+	requestOptions := RequestOptions{}
+	if request.GetOptions() != nil {
+		requestOptions = request.GetOptions().RequestOptions
+	}
 
 	authorizationModelId, err := client.getAuthorizationModelId(request.GetAuthorizationModelIdOverride())
 	if err != nil {
@@ -1577,7 +1670,12 @@ func (client *OpenFgaClient) WriteExecute(request SdkClientWriteRequestInterface
 			}
 			writeRequest.Deletes = &deletes
 		}
-		_, httpResponse, err := client.OpenFgaApi.Write(request.GetContext(), *storeId).Body(writeRequest).Execute()
+
+		_, httpResponse, err := client.OpenFgaApi.
+			Write(request.GetContext(), *storeId).
+			Body(writeRequest).
+			Options(requestOptions).
+			Execute()
 
 		clientWriteStatus := SUCCESS
 		if err != nil {
@@ -1649,6 +1747,7 @@ func (client *OpenFgaClient) WriteExecute(request SdkClientWriteRequestInterface
 					Writes: writeBody,
 				},
 				options: &ClientWriteOptions{
+					RequestOptions:       options.RequestOptions,
 					AuthorizationModelId: authorizationModelId,
 					StoreId:              request.GetStoreIdOverride(),
 				},
@@ -1693,6 +1792,7 @@ func (client *OpenFgaClient) WriteExecute(request SdkClientWriteRequestInterface
 					Deletes: deleteBody,
 				},
 				options: &ClientWriteOptions{
+					RequestOptions:       options.RequestOptions,
 					AuthorizationModelId: authorizationModelId,
 					StoreId:              request.GetStoreIdOverride(),
 				},
@@ -1886,6 +1986,8 @@ type ClientCheckRequest struct {
 }
 
 type ClientCheckOptions struct {
+	RequestOptions
+
 	AuthorizationModelId *string                       `json:"authorization_model_id,omitempty"`
 	StoreId              *string                       `json:"store_id,omitempty"`
 	Consistency          *fgaSdk.ConsistencyPreference `json:"consistency,omitempty"`
@@ -1944,10 +2046,11 @@ func (request *SdkClientCheckRequest) GetOptions() *ClientCheckOptions {
 }
 
 func (client *OpenFgaClient) CheckExecute(request SdkClientCheckRequestInterface) (*ClientCheckResponse, error) {
+	if request.GetBody() == nil {
+		return nil, FgaRequiredParamError{param: "body"}
+	}
+
 	var contextualTuples []ClientContextualTupleKey
-    if request.GetBody() == nil {
-        return nil, FgaRequiredParamError{param: "body"}
-    }
 	if request.GetBody().ContextualTuples != nil {
 		for index := 0; index < len(request.GetBody().ContextualTuples); index++ {
 			contextualTuples = append(contextualTuples, (request.GetBody().ContextualTuples)[index])
@@ -1972,11 +2075,17 @@ func (client *OpenFgaClient) CheckExecute(request SdkClientCheckRequestInterface
 		AuthorizationModelId: authorizationModelId,
 	}
 
+	requestOptions := RequestOptions{}
 	if request.GetOptions() != nil {
+		requestOptions = request.GetOptions().RequestOptions
 		requestBody.Consistency = request.GetOptions().Consistency
 	}
 
-	data, httpResponse, err := client.OpenFgaApi.Check(request.GetContext(), *storeId).Body(requestBody).Execute()
+	data, httpResponse, err := client.OpenFgaApi.
+		Check(request.GetContext(), *storeId).
+		Body(requestBody).
+		Options(requestOptions).
+		Execute()
 	return &ClientCheckResponse{CheckResponse: data, HttpResponse: httpResponse}, err
 }
 
@@ -2005,6 +2114,8 @@ type SdkClientBatchCheckClientRequestInterface interface {
 type ClientBatchCheckClientBody = []ClientCheckRequest
 
 type ClientBatchCheckClientOptions struct {
+	RequestOptions
+
 	AuthorizationModelId *string                       `json:"authorization_model_id,omitempty"`
 	StoreId              *string                       `json:"store_id,omitempty"`
 	MaxParallelRequests  *int32                        `json:"max_parallel_requests,omitempty"`
@@ -2068,12 +2179,15 @@ func (request *SdkClientBatchCheckClientRequest) GetOptions() *ClientBatchCheckC
 
 func (client *OpenFgaClient) ClientBatchCheckExecute(request SdkClientBatchCheckClientRequestInterface) (*ClientBatchCheckClientResponse, error) {
 	group, ctx := errgroup.WithContext(request.GetContext())
-	var maxParallelReqs int
-	if request.GetOptions() == nil || request.GetOptions().MaxParallelRequests == nil {
-		maxParallelReqs = int(DEFAULT_MAX_METHOD_PARALLEL_REQS)
-	} else {
-		maxParallelReqs = int(*request.GetOptions().MaxParallelRequests)
+	requestOptions := RequestOptions{}
+	maxParallelReqs := int(DEFAULT_MAX_METHOD_PARALLEL_REQS)
+	if request.GetOptions() != nil {
+		requestOptions = request.GetOptions().RequestOptions
+		if request.GetOptions().MaxParallelRequests != nil {
+			maxParallelReqs = int(*request.GetOptions().MaxParallelRequests)
+		}
 	}
+
 	group.SetLimit(maxParallelReqs)
 	var numOfChecks = len(*request.GetBody())
 	response := make(ClientBatchCheckClientResponse, numOfChecks)
@@ -2088,6 +2202,8 @@ func (client *OpenFgaClient) ClientBatchCheckExecute(request SdkClientBatchCheck
 	}
 
 	checkOptions := &ClientCheckOptions{
+		RequestOptions: requestOptions,
+
 		AuthorizationModelId: authorizationModelId,
 		StoreId:              storeId,
 	}
@@ -2264,9 +2380,10 @@ func (client *OpenFgaClient) singleBatchCheck(ctx _context.Context, body fgaSdk.
 		return nil, err
 	}
 
-	req := client.OpenFgaApi.BatchCheck(ctx, *storeId)
-	req = req.Body(body)
-
+	req := client.OpenFgaApi.
+		BatchCheck(ctx, *storeId).
+		Body(body).
+		Options(options.RequestOptions)
 	response, _, err := req.Execute()
 	if err != nil {
 		return nil, err
@@ -2381,6 +2498,8 @@ type ClientExpandRequest struct {
 }
 
 type ClientExpandOptions struct {
+	RequestOptions
+
 	AuthorizationModelId *string                       `json:"authorization_model_id,omitempty"`
 	StoreId              *string                       `json:"store_id,omitempty"`
 	Consistency          *fgaSdk.ConsistencyPreference `json:"consistency,omitempty"`
@@ -2461,11 +2580,17 @@ func (client *OpenFgaClient) ExpandExecute(request SdkClientExpandRequestInterfa
 		AuthorizationModelId: authorizationModelId,
 	}
 
+	requestOptions := RequestOptions{}
 	if request.GetOptions() != nil {
+		requestOptions = request.GetOptions().RequestOptions
 		body.Consistency = request.GetOptions().Consistency
 	}
 
-	data, _, err := client.OpenFgaApi.Expand(request.GetContext(), *storeId).Body(body).Execute()
+	data, _, err := client.OpenFgaApi.
+		Expand(request.GetContext(), *storeId).
+		Body(body).
+		Options(requestOptions).
+		Execute()
 	if err != nil {
 		return nil, err
 	}
@@ -2502,6 +2627,8 @@ type ClientListObjectsRequest struct {
 }
 
 type ClientListObjectsOptions struct {
+	RequestOptions
+
 	AuthorizationModelId *string                       `json:"authorization_model_id,omitempty"`
 	StoreId              *string                       `json:"store_id,omitempty"`
 	Consistency          *fgaSdk.ConsistencyPreference `json:"consistency,omitempty"`
@@ -2579,10 +2706,16 @@ func (client *OpenFgaClient) ListObjectsExecute(request SdkClientListObjectsRequ
 		Context:              request.GetBody().Context,
 		AuthorizationModelId: authorizationModelId,
 	}
+	requestOptions := RequestOptions{}
 	if request.GetOptions() != nil {
+		requestOptions = request.GetOptions().RequestOptions
 		body.Consistency = request.GetOptions().Consistency
 	}
-	data, _, err := client.OpenFgaApi.ListObjects(request.GetContext(), *storeId).Body(body).Execute()
+	data, _, err := client.OpenFgaApi.
+		ListObjects(request.GetContext(), *storeId).
+		Body(body).
+		Options(requestOptions).
+		Execute()
 	if err != nil {
 		return nil, err
 	}
@@ -2620,6 +2753,8 @@ type ClientListRelationsRequest struct {
 }
 
 type ClientListRelationsOptions struct {
+	RequestOptions
+
 	AuthorizationModelId *string                       `json:"authorization_model_id,omitempty"`
 	MaxParallelRequests  *int32                        `json:"max_parallel_requests,omitempty"`
 	StoreId              *string                       `json:"store_id,omitempty"`
@@ -2712,6 +2847,7 @@ func (client *OpenFgaClient) ListRelationsExecute(request SdkClientListRelations
 		StoreId:              storeId,
 	}
 	if request.GetOptions() != nil {
+		options.RequestOptions = request.GetOptions().RequestOptions
 		options.Consistency = request.GetOptions().Consistency
 		options.MaxParallelRequests = request.GetOptions().MaxParallelRequests
 	}
@@ -2768,6 +2904,8 @@ type ClientListUsersRequest struct {
 }
 
 type ClientListUsersOptions struct {
+	RequestOptions
+
 	AuthorizationModelId *string                       `json:"authorization_model_id,omitempty"`
 	StoreId              *string                       `json:"store_id,omitempty"`
 	Consistency          *fgaSdk.ConsistencyPreference `json:"consistency,omitempty"`
@@ -2846,11 +2984,17 @@ func (client *OpenFgaClient) ListUsersExecute(request SdkClientListUsersRequestI
 		AuthorizationModelId: authorizationModelId,
 	}
 
+	requestOptions := RequestOptions{}
 	if request.GetOptions() != nil {
+		requestOptions = request.GetOptions().RequestOptions
 		body.Consistency = request.GetOptions().Consistency
 	}
 
-	data, _, err := client.OpenFgaApi.ListUsers(request.GetContext(), *storeId).Body(body).Execute()
+	data, _, err := client.OpenFgaApi.
+		ListUsers(request.GetContext(), *storeId).
+		Body(body).
+		Options(requestOptions).
+		Execute()
 	if err != nil {
 		return nil, err
 	}
@@ -2876,6 +3020,8 @@ type SdkClientReadAssertionsRequestInterface interface {
 }
 
 type ClientReadAssertionsOptions struct {
+	RequestOptions
+
 	AuthorizationModelId *string `json:"authorization_model_id,omitempty"`
 	StoreId              *string `json:"store_id,omitempty"`
 }
@@ -2932,7 +3078,16 @@ func (client *OpenFgaClient) ReadAssertionsExecute(request SdkClientReadAssertio
 	if err != nil {
 		return nil, err
 	}
-	data, _, err := client.OpenFgaApi.ReadAssertions(request.GetContext(), *storeId, *authorizationModelId).Execute()
+
+	requestOptions := RequestOptions{}
+	if request.GetOptions() != nil {
+		requestOptions = request.GetOptions().RequestOptions
+	}
+
+	data, _, err := client.OpenFgaApi.
+		ReadAssertions(request.GetContext(), *storeId, *authorizationModelId).
+		Options(requestOptions).
+		Execute()
 	if err != nil {
 		return nil, err
 	}
@@ -2990,6 +3145,8 @@ func (clientAssertion ClientAssertion) ToAssertion() fgaSdk.Assertion {
 }
 
 type ClientWriteAssertionsOptions struct {
+	RequestOptions
+
 	AuthorizationModelId *string `json:"authorization_model_id,omitempty"`
 	StoreId              *string `json:"store_id,omitempty"`
 }
@@ -3061,7 +3218,17 @@ func (client *OpenFgaClient) WriteAssertionsExecute(request SdkClientWriteAssert
 		clientAssertion := (*request.GetBody())[index]
 		writeAssertionsRequest.Assertions = append(writeAssertionsRequest.Assertions, clientAssertion.ToAssertion())
 	}
-	_, err = client.OpenFgaApi.WriteAssertions(request.GetContext(), *storeId, *authorizationModelId).Body(writeAssertionsRequest).Execute()
+
+	requestOptions := RequestOptions{}
+	if request.GetOptions() != nil {
+		requestOptions = request.GetOptions().RequestOptions
+	}
+
+	_, err = client.OpenFgaApi.
+		WriteAssertions(request.GetContext(), *storeId, *authorizationModelId).
+		Body(writeAssertionsRequest).
+		Options(requestOptions).
+		Execute()
 
 	if err != nil {
 		return nil, err

--- a/client/client_headers_test.go
+++ b/client/client_headers_test.go
@@ -1,0 +1,892 @@
+package client_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	fgaSdk "github.com/openfga/go-sdk"
+	fgaSdkClient "github.com/openfga/go-sdk/client"
+)
+
+// Test helpers and setup
+
+// Constants to avoid duplication
+const (
+	defaultHeaderName           = "Default-Header"
+	defaultHeaderValue          = "default-value"
+	overriddenValue             = "overridden-value"
+	customHeaderName            = "X-Custom-Header"
+	customHeaderValue           = "custom-value"
+	testUser                    = "user:anne"
+	testRelation                = "viewer"
+	testObject                  = "document:roadmap"
+	testHeaderName              = "Test-Header"
+	testHeaderValue             = "test-value"
+	checkRequestFailedMsg       = "Check request failed: %v"
+	expectedCustomHeaderMsg     = "Expected X-Custom-Header to be 'custom-value', got '%s'"
+	expectedOverriddenHeaderMsg = "Expected Default-Header to be overridden to 'overridden-value', got '%s'"
+	expectedDefaultHeaderMsg    = "Expected Default-Header to be 'default-value', got '%s'"
+)
+
+func createTestServer(t *testing.T, capturedHeaders *map[string]string, responseBody string) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*capturedHeaders = make(map[string]string)
+		for name, values := range r.Header {
+			if len(values) > 0 {
+				(*capturedHeaders)[name] = values[0]
+			}
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(responseBody))
+	}))
+}
+
+func createTestClient(t *testing.T, serverURL string, defaultHeaders map[string]string) *fgaSdkClient.OpenFgaClient {
+	t.Helper()
+
+	config := fgaSdkClient.ClientConfiguration{
+		ApiUrl:         serverURL,
+		DefaultHeaders: defaultHeaders,
+		StoreId:        "01H0H015178Y2V4CX10C2KGHF4",
+		HTTPClient:     &http.Client{},
+	}
+
+	client, err := fgaSdkClient.NewSdkClient(&config)
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	return client
+}
+
+// Test RequestOptions
+func TestRequestOptionsStructure(t *testing.T) {
+	t.Run("RequestOptionsEmbedding", func(t *testing.T) {
+		options := fgaSdkClient.ClientCheckOptions{
+			RequestOptions: fgaSdkClient.RequestOptions{
+				Headers: map[string]string{
+					testHeaderName: testHeaderValue,
+				},
+				MaxRetry:    fgaSdk.PtrInt(3),
+				MinWaitInMs: fgaSdk.PtrInt(1000),
+			},
+			AuthorizationModelId: fgaSdk.PtrString("01H0H015178Y2V4CX10C2KGHF4"),
+			Consistency:          nil,
+		}
+
+		if options.Headers[testHeaderName] != testHeaderValue {
+			t.Errorf("Expected %s to be '%s', got '%s'", testHeaderName, testHeaderValue, options.Headers[testHeaderName])
+		}
+
+		if options.MaxRetry == nil || *options.MaxRetry != 3 {
+			t.Errorf("Expected MaxRetry to be 3, got %v", options.MaxRetry)
+		}
+
+		if options.MinWaitInMs == nil || *options.MinWaitInMs != 1000 {
+			t.Errorf("Expected MinWaitInMs to be 1000, got %v", options.MinWaitInMs)
+		}
+
+		if options.AuthorizationModelId == nil || *options.AuthorizationModelId != "01H0H015178Y2V4CX10C2KGHF4" {
+			t.Errorf("Expected AuthorizationModelId to be set correctly")
+		}
+	})
+
+	t.Run("RequestWithNilHeaders", func(t *testing.T) {
+		options := fgaSdkClient.ClientCheckOptions{
+			RequestOptions: fgaSdkClient.RequestOptions{
+				Headers:     nil,
+				MaxRetry:    fgaSdk.PtrInt(3),
+				MinWaitInMs: fgaSdk.PtrInt(1000),
+			},
+		}
+
+		if options.Headers != nil {
+			t.Errorf("Expected Headers to be nil, got %v", options.Headers)
+		}
+	})
+}
+
+// Test the header handling for the methods
+
+func TestCheckMethodHeaderHandling(t *testing.T) {
+	t.Run("CheckWithCustomHeaders", func(t *testing.T) {
+		var capturedHeaders map[string]string
+		server := createTestServer(t, &capturedHeaders, `{"allowed": true}`)
+		defer server.Close()
+
+		client := createTestClient(t, server.URL, map[string]string{
+			defaultHeaderName: defaultHeaderValue,
+		})
+
+		_, err := client.Check(context.Background()).
+			Body(fgaSdkClient.ClientCheckRequest{
+				User:     testUser,
+				Relation: testRelation,
+				Object:   testObject,
+			}).
+			Options(fgaSdkClient.ClientCheckOptions{
+				RequestOptions: fgaSdkClient.RequestOptions{
+					Headers: map[string]string{
+						customHeaderName:  customHeaderValue,
+						defaultHeaderName: overriddenValue,
+					},
+				},
+			}).
+			Execute()
+
+		if err != nil {
+			t.Fatalf(checkRequestFailedMsg, err)
+		}
+
+		if capturedHeaders[customHeaderName] != customHeaderValue {
+			t.Errorf(expectedCustomHeaderMsg, capturedHeaders[customHeaderName])
+		}
+
+		if capturedHeaders[defaultHeaderName] != overriddenValue {
+			t.Errorf(expectedOverriddenHeaderMsg, capturedHeaders[defaultHeaderName])
+		}
+	})
+
+	t.Run("CheckWithoutCustomHeaders", func(t *testing.T) {
+		var capturedHeaders map[string]string
+		server := createTestServer(t, &capturedHeaders, `{"allowed": true}`)
+		defer server.Close()
+
+		client := createTestClient(t, server.URL, map[string]string{
+			defaultHeaderName: defaultHeaderValue,
+		})
+
+		_, err := client.Check(context.Background()).
+			Body(fgaSdkClient.ClientCheckRequest{
+				User:     testUser,
+				Relation: testRelation,
+				Object:   testObject,
+			}).
+			Execute()
+
+		if err != nil {
+			t.Fatalf(checkRequestFailedMsg, err)
+		}
+
+		if capturedHeaders[defaultHeaderName] != defaultHeaderValue {
+			t.Errorf(expectedDefaultHeaderMsg, capturedHeaders[defaultHeaderName])
+		}
+
+		if _, exists := capturedHeaders[customHeaderName]; exists {
+			t.Error("Did not expect X-Custom-Header to be present")
+		}
+	})
+
+	t.Run("CheckWithEmptyHeaders", func(t *testing.T) {
+		var capturedHeaders map[string]string
+		server := createTestServer(t, &capturedHeaders, `{"allowed": true}`)
+		defer server.Close()
+
+		client := createTestClient(t, server.URL, nil)
+
+		_, err := client.Check(context.Background()).
+			Body(fgaSdkClient.ClientCheckRequest{
+				User:     testUser,
+				Relation: testRelation,
+				Object:   testObject,
+			}).
+			Options(fgaSdkClient.ClientCheckOptions{
+				RequestOptions: fgaSdkClient.RequestOptions{
+					Headers: map[string]string{},
+				},
+			}).
+			Execute()
+
+		if err != nil {
+			t.Fatalf(checkRequestFailedMsg, err)
+		}
+
+		// Only standard headers should be present
+		for header := range capturedHeaders {
+			if strings.HasPrefix(header, "X-") || header == defaultHeaderName {
+				t.Errorf("Unexpected custom header found: %s", header)
+			}
+		}
+	})
+
+	t.Run("CheckWithNilOptions", func(t *testing.T) {
+		var capturedHeaders map[string]string
+		server := createTestServer(t, &capturedHeaders, `{"allowed": true}`)
+		defer server.Close()
+
+		client := createTestClient(t, server.URL, map[string]string{
+			defaultHeaderName: defaultHeaderValue,
+		})
+
+		request := client.Check(context.Background()).
+			Body(fgaSdkClient.ClientCheckRequest{
+				User:     testUser,
+				Relation: testRelation,
+				Object:   testObject,
+			})
+
+		// Options not set
+		_, err := request.Execute()
+
+		if err != nil {
+			t.Fatalf(checkRequestFailedMsg, err)
+		}
+
+		if capturedHeaders[defaultHeaderName] != defaultHeaderValue {
+			t.Errorf(expectedDefaultHeaderMsg, capturedHeaders[defaultHeaderName])
+		}
+	})
+}
+
+func TestWriteMethodHeaderHandling(t *testing.T) {
+	const writeResponse = `{}`
+
+	t.Run("WriteWithCustomHeaders", func(t *testing.T) {
+		var capturedHeaders map[string]string
+		server := createTestServer(t, &capturedHeaders, writeResponse)
+		defer server.Close()
+
+		client := createTestClient(t, server.URL, map[string]string{
+			defaultHeaderName: defaultHeaderValue,
+		})
+
+		_, err := client.Write(context.Background()).
+			Body(fgaSdkClient.ClientWriteRequest{
+				Writes: []fgaSdkClient.ClientTupleKey{
+					{
+						User:     testUser,
+						Relation: testRelation,
+						Object:   testObject,
+					},
+				},
+			}).
+			Options(fgaSdkClient.ClientWriteOptions{
+				RequestOptions: fgaSdkClient.RequestOptions{
+					Headers: map[string]string{
+						customHeaderName:  customHeaderValue,
+						defaultHeaderName: overriddenValue,
+					},
+				},
+			}).
+			Execute()
+
+		if err != nil {
+			t.Fatalf(checkRequestFailedMsg, err)
+		}
+
+		if capturedHeaders[customHeaderName] != customHeaderValue {
+			t.Errorf(expectedCustomHeaderMsg, capturedHeaders[customHeaderName])
+		}
+
+		if capturedHeaders[defaultHeaderName] != overriddenValue {
+			t.Errorf(expectedOverriddenHeaderMsg, capturedHeaders[defaultHeaderName])
+		}
+	})
+
+	t.Run("WriteWithoutCustomHeaders", func(t *testing.T) {
+		var capturedHeaders map[string]string
+		server := createTestServer(t, &capturedHeaders, writeResponse)
+		defer server.Close()
+
+		client := createTestClient(t, server.URL, map[string]string{
+			defaultHeaderName: defaultHeaderValue,
+		})
+
+		_, err := client.Write(context.Background()).
+			Body(fgaSdkClient.ClientWriteRequest{
+				Writes: []fgaSdkClient.ClientTupleKey{
+					{
+						User:     testUser,
+						Relation: testRelation,
+						Object:   testObject,
+					},
+				},
+			}).
+			Execute()
+
+		if err != nil {
+			t.Fatalf(checkRequestFailedMsg, err)
+		}
+
+		if capturedHeaders[defaultHeaderName] != defaultHeaderValue {
+			t.Errorf(expectedDefaultHeaderMsg, capturedHeaders[defaultHeaderName])
+		}
+	})
+}
+
+func TestReadMethodHeaderHandling(t *testing.T) {
+	const readResponse = `{"tuples": []}`
+
+	t.Run("ReadWithCustomHeaders", func(t *testing.T) {
+		var capturedHeaders map[string]string
+		server := createTestServer(t, &capturedHeaders, readResponse)
+		defer server.Close()
+
+		client := createTestClient(t, server.URL, map[string]string{
+			defaultHeaderName: defaultHeaderValue,
+		})
+
+		_, err := client.Read(context.Background()).
+			Body(fgaSdkClient.ClientReadRequest{
+				User:     fgaSdk.PtrString(testUser),
+				Relation: fgaSdk.PtrString(testRelation),
+				Object:   fgaSdk.PtrString(testObject),
+			}).
+			Options(fgaSdkClient.ClientReadOptions{
+				RequestOptions: fgaSdkClient.RequestOptions{
+					Headers: map[string]string{
+						customHeaderName:  customHeaderValue,
+						defaultHeaderName: overriddenValue,
+					},
+				},
+			}).
+			Execute()
+
+		if err != nil {
+			t.Fatalf(checkRequestFailedMsg, err)
+		}
+
+		if capturedHeaders[customHeaderName] != customHeaderValue {
+			t.Errorf(expectedCustomHeaderMsg, capturedHeaders[customHeaderName])
+		}
+
+		if capturedHeaders[defaultHeaderName] != overriddenValue {
+			t.Errorf(expectedOverriddenHeaderMsg, capturedHeaders[defaultHeaderName])
+		}
+	})
+}
+
+func TestExpandMethodHeaderHandling(t *testing.T) {
+	const expandResponse = `{"tree": {"root": {"name": "document:roadmap#viewer"}}}`
+
+	t.Run("ExpandWithCustomHeaders", func(t *testing.T) {
+		var capturedHeaders map[string]string
+		server := createTestServer(t, &capturedHeaders, expandResponse)
+		defer server.Close()
+
+		client := createTestClient(t, server.URL, map[string]string{
+			defaultHeaderName: defaultHeaderValue,
+		})
+
+		_, err := client.Expand(context.Background()).
+			Body(fgaSdkClient.ClientExpandRequest{
+				Relation: testRelation,
+				Object:   testObject,
+			}).
+			Options(fgaSdkClient.ClientExpandOptions{
+				RequestOptions: fgaSdkClient.RequestOptions{
+					Headers: map[string]string{
+						customHeaderName:  customHeaderValue,
+						defaultHeaderName: overriddenValue,
+					},
+				},
+			}).
+			Execute()
+
+		if err != nil {
+			t.Fatalf(checkRequestFailedMsg, err)
+		}
+
+		if capturedHeaders[customHeaderName] != customHeaderValue {
+			t.Errorf(expectedCustomHeaderMsg, capturedHeaders[customHeaderName])
+		}
+
+		if capturedHeaders[defaultHeaderName] != overriddenValue {
+			t.Errorf(expectedOverriddenHeaderMsg, capturedHeaders[defaultHeaderName])
+		}
+	})
+}
+
+func TestListObjectsMethodHeaderHandling(t *testing.T) {
+	const listObjectsResponse = `{"objects": ["document:roadmap"]}`
+
+	t.Run("ListObjectsWithCustomHeaders", func(t *testing.T) {
+		var capturedHeaders map[string]string
+		server := createTestServer(t, &capturedHeaders, listObjectsResponse)
+		defer server.Close()
+
+		client := createTestClient(t, server.URL, map[string]string{
+			defaultHeaderName: defaultHeaderValue,
+		})
+
+		_, err := client.ListObjects(context.Background()).
+			Body(fgaSdkClient.ClientListObjectsRequest{
+				User:     testUser,
+				Relation: testRelation,
+				Type:     "document",
+			}).
+			Options(fgaSdkClient.ClientListObjectsOptions{
+				RequestOptions: fgaSdkClient.RequestOptions{
+					Headers: map[string]string{
+						customHeaderName:  customHeaderValue,
+						defaultHeaderName: overriddenValue,
+					},
+				},
+			}).
+			Execute()
+
+		if err != nil {
+			t.Fatalf(checkRequestFailedMsg, err)
+		}
+
+		if capturedHeaders[customHeaderName] != customHeaderValue {
+			t.Errorf(expectedCustomHeaderMsg, capturedHeaders[customHeaderName])
+		}
+
+		if capturedHeaders[defaultHeaderName] != overriddenValue {
+			t.Errorf(expectedOverriddenHeaderMsg, capturedHeaders[defaultHeaderName])
+		}
+	})
+}
+
+func TestListUsersMethodHeaderHandling(t *testing.T) {
+	const listUsersResponse = `{"users": [{"object": {"type": "user", "id": "anne"}}]}`
+
+	t.Run("ListUsersWithCustomHeaders", func(t *testing.T) {
+		var capturedHeaders map[string]string
+		server := createTestServer(t, &capturedHeaders, listUsersResponse)
+		defer server.Close()
+
+		client := createTestClient(t, server.URL, map[string]string{
+			defaultHeaderName: defaultHeaderValue,
+		})
+
+		_, err := client.ListUsers(context.Background()).
+			Body(fgaSdkClient.ClientListUsersRequest{
+				Object: fgaSdk.FgaObject{
+					Type: "document",
+					Id:   "roadmap",
+				},
+				Relation: testRelation,
+				UserFilters: []fgaSdk.UserTypeFilter{
+					{Type: "user"},
+				},
+			}).
+			Options(fgaSdkClient.ClientListUsersOptions{
+				RequestOptions: fgaSdkClient.RequestOptions{
+					Headers: map[string]string{
+						customHeaderName:  customHeaderValue,
+						defaultHeaderName: overriddenValue,
+					},
+				},
+			}).
+			Execute()
+
+		if err != nil {
+			t.Fatalf(checkRequestFailedMsg, err)
+		}
+
+		if capturedHeaders[customHeaderName] != customHeaderValue {
+			t.Errorf(expectedCustomHeaderMsg, capturedHeaders[customHeaderName])
+		}
+
+		if capturedHeaders[defaultHeaderName] != overriddenValue {
+			t.Errorf(expectedOverriddenHeaderMsg, capturedHeaders[defaultHeaderName])
+		}
+	})
+}
+
+func TestBatchCheckMethodHeaderHandling(t *testing.T) {
+	const batchCheckResponse = `[{"allowed": true}]`
+
+	t.Run("BatchCheckWithCustomHeaders", func(t *testing.T) {
+		var capturedHeaders map[string]string
+		server := createTestServer(t, &capturedHeaders, batchCheckResponse)
+		defer server.Close()
+
+		client := createTestClient(t, server.URL, map[string]string{
+			defaultHeaderName: defaultHeaderValue,
+		})
+
+		checks := []fgaSdkClient.ClientCheckRequest{
+			{
+				User:     testUser,
+				Relation: testRelation,
+				Object:   testObject,
+			},
+		}
+
+		_, err := client.ClientBatchCheck(context.Background()).
+			Body(checks).
+			Options(fgaSdkClient.ClientBatchCheckClientOptions{
+				RequestOptions: fgaSdkClient.RequestOptions{
+					Headers: map[string]string{
+						customHeaderName:  customHeaderValue,
+						defaultHeaderName: overriddenValue,
+					},
+				},
+			}).
+			Execute()
+
+		if err != nil {
+			t.Fatalf(checkRequestFailedMsg, err)
+		}
+
+		if capturedHeaders[customHeaderName] != customHeaderValue {
+			t.Errorf(expectedCustomHeaderMsg, capturedHeaders[customHeaderName])
+		}
+
+		if capturedHeaders[defaultHeaderName] != overriddenValue {
+			t.Errorf(expectedOverriddenHeaderMsg, capturedHeaders[defaultHeaderName])
+		}
+	})
+}
+
+func TestReadAuthorizationModelMethodHeaderHandling(t *testing.T) {
+	const authModelResponse = `{"authorization_model": {"id": "01H0H015178Y2V4CX10C2KGHF4", "schema_version": "1.1"}}`
+
+	t.Run("ReadAuthorizationModelWithCustomHeaders", func(t *testing.T) {
+		var capturedHeaders map[string]string
+		server := createTestServer(t, &capturedHeaders, authModelResponse)
+		defer server.Close()
+
+		client := createTestClient(t, server.URL, map[string]string{
+			defaultHeaderName: defaultHeaderValue,
+		})
+
+		_, err := client.ReadAuthorizationModel(context.Background()).
+			Options(fgaSdkClient.ClientReadAuthorizationModelOptions{
+				RequestOptions: fgaSdkClient.RequestOptions{
+					Headers: map[string]string{
+						customHeaderName:  customHeaderValue,
+						defaultHeaderName: overriddenValue,
+					},
+				},
+				AuthorizationModelId: fgaSdk.PtrString("01H0H015178Y2V4CX10C2KGHF4"),
+			}).
+			Execute()
+
+		if err != nil {
+			t.Fatalf(checkRequestFailedMsg, err)
+		}
+
+		if capturedHeaders[customHeaderName] != customHeaderValue {
+			t.Errorf(expectedCustomHeaderMsg, capturedHeaders[customHeaderName])
+		}
+
+		if capturedHeaders[defaultHeaderName] != overriddenValue {
+			t.Errorf(expectedOverriddenHeaderMsg, capturedHeaders[defaultHeaderName])
+		}
+	})
+}
+
+func TestWriteAuthorizationModelMethodHeaderHandling(t *testing.T) {
+	const writeAuthModelResponse = `{"authorization_model_id": "01H0H015178Y2V4CX10C2KGHF4"}`
+
+	t.Run("WriteAuthorizationModelWithCustomHeaders", func(t *testing.T) {
+		var capturedHeaders map[string]string
+		server := createTestServer(t, &capturedHeaders, writeAuthModelResponse)
+		defer server.Close()
+
+		client := createTestClient(t, server.URL, map[string]string{
+			defaultHeaderName: defaultHeaderValue,
+		})
+
+		_, err := client.WriteAuthorizationModel(context.Background()).
+			Body(fgaSdkClient.ClientWriteAuthorizationModelRequest{
+				SchemaVersion: "1.1",
+				TypeDefinitions: []fgaSdk.TypeDefinition{
+					{
+						Type: "user",
+					},
+					{
+						Type: "document",
+						Relations: &map[string]fgaSdk.Userset{
+							"viewer": {},
+						},
+					},
+				},
+			}).
+			Options(fgaSdkClient.ClientWriteAuthorizationModelOptions{
+				RequestOptions: fgaSdkClient.RequestOptions{
+					Headers: map[string]string{
+						customHeaderName:  customHeaderValue,
+						defaultHeaderName: overriddenValue,
+					},
+				},
+			}).
+			Execute()
+
+		if err != nil {
+			t.Fatalf(checkRequestFailedMsg, err)
+		}
+
+		if capturedHeaders[customHeaderName] != customHeaderValue {
+			t.Errorf(expectedCustomHeaderMsg, capturedHeaders[customHeaderName])
+		}
+
+		if capturedHeaders[defaultHeaderName] != overriddenValue {
+			t.Errorf(expectedOverriddenHeaderMsg, capturedHeaders[defaultHeaderName])
+		}
+	})
+}
+
+func TestStoreMethodHeaderHandling(t *testing.T) {
+	t.Run("ListStoresWithCustomHeaders", func(t *testing.T) {
+		const listStoresResponse = `{"stores": [{"id": "01H0H015178Y2V4CX10C2KGHF4", "name": "test"}]}`
+		var capturedHeaders map[string]string
+		server := createTestServer(t, &capturedHeaders, listStoresResponse)
+		defer server.Close()
+
+		client := createTestClient(t, server.URL, map[string]string{
+			defaultHeaderName: defaultHeaderValue,
+		})
+
+		_, err := client.ListStores(context.Background()).
+			Options(fgaSdkClient.ClientListStoresOptions{
+				RequestOptions: fgaSdkClient.RequestOptions{
+					Headers: map[string]string{
+						customHeaderName:  customHeaderValue,
+						defaultHeaderName: overriddenValue,
+					},
+				},
+			}).
+			Execute()
+
+		if err != nil {
+			t.Fatalf(checkRequestFailedMsg, err)
+		}
+
+		if capturedHeaders[customHeaderName] != customHeaderValue {
+			t.Errorf(expectedCustomHeaderMsg, capturedHeaders[customHeaderName])
+		}
+
+		if capturedHeaders[defaultHeaderName] != overriddenValue {
+			t.Errorf(expectedOverriddenHeaderMsg, capturedHeaders[defaultHeaderName])
+		}
+	})
+
+	t.Run("CreateStoreWithCustomHeaders", func(t *testing.T) {
+		const createStoreResponse = `{"id": "01H0H015178Y2V4CX10C2KGHF4", "name": "test"}`
+		var capturedHeaders map[string]string
+		server := createTestServer(t, &capturedHeaders, createStoreResponse)
+		defer server.Close()
+
+		client := createTestClient(t, server.URL, map[string]string{
+			defaultHeaderName: defaultHeaderValue,
+		})
+
+		_, err := client.CreateStore(context.Background()).
+			Body(fgaSdkClient.ClientCreateStoreRequest{
+				Name: "test",
+			}).
+			Options(fgaSdkClient.ClientCreateStoreOptions{
+				RequestOptions: fgaSdkClient.RequestOptions{
+					Headers: map[string]string{
+						customHeaderName:  customHeaderValue,
+						defaultHeaderName: overriddenValue,
+					},
+				},
+			}).
+			Execute()
+
+		if err != nil {
+			t.Fatalf(checkRequestFailedMsg, err)
+		}
+
+		if capturedHeaders[customHeaderName] != customHeaderValue {
+			t.Errorf(expectedCustomHeaderMsg, capturedHeaders[customHeaderName])
+		}
+
+		if capturedHeaders[defaultHeaderName] != overriddenValue {
+			t.Errorf(expectedOverriddenHeaderMsg, capturedHeaders[defaultHeaderName])
+		}
+	})
+
+	t.Run("GetStoreWithCustomHeaders", func(t *testing.T) {
+		const getStoreResponse = `{"id": "01H0H015178Y2V4CX10C2KGHF4", "name": "test"}`
+		var capturedHeaders map[string]string
+		server := createTestServer(t, &capturedHeaders, getStoreResponse)
+		defer server.Close()
+
+		client := createTestClient(t, server.URL, map[string]string{
+			defaultHeaderName: defaultHeaderValue,
+		})
+
+		_, err := client.GetStore(context.Background()).
+			Options(fgaSdkClient.ClientGetStoreOptions{
+				RequestOptions: fgaSdkClient.RequestOptions{
+					Headers: map[string]string{
+						customHeaderName:  customHeaderValue,
+						defaultHeaderName: overriddenValue,
+					},
+				},
+			}).
+			Execute()
+
+		if err != nil {
+			t.Fatalf(checkRequestFailedMsg, err)
+		}
+
+		if capturedHeaders[customHeaderName] != customHeaderValue {
+			t.Errorf(expectedCustomHeaderMsg, capturedHeaders[customHeaderName])
+		}
+
+		if capturedHeaders[defaultHeaderName] != overriddenValue {
+			t.Errorf(expectedOverriddenHeaderMsg, capturedHeaders[defaultHeaderName])
+		}
+	})
+
+	t.Run("DeleteStoreWithCustomHeaders", func(t *testing.T) {
+		const deleteStoreResponse = `{}`
+		var capturedHeaders map[string]string
+		server := createTestServer(t, &capturedHeaders, deleteStoreResponse)
+		defer server.Close()
+
+		client := createTestClient(t, server.URL, map[string]string{
+			defaultHeaderName: defaultHeaderValue,
+		})
+
+		_, err := client.DeleteStore(context.Background()).
+			Options(fgaSdkClient.ClientDeleteStoreOptions{
+				RequestOptions: fgaSdkClient.RequestOptions{
+					Headers: map[string]string{
+						customHeaderName:  customHeaderValue,
+						defaultHeaderName: overriddenValue,
+					},
+				},
+			}).
+			Execute()
+
+		if err != nil {
+			t.Fatalf(checkRequestFailedMsg, err)
+		}
+
+		if capturedHeaders[customHeaderName] != customHeaderValue {
+			t.Errorf(expectedCustomHeaderMsg, capturedHeaders[customHeaderName])
+		}
+
+		if capturedHeaders[defaultHeaderName] != overriddenValue {
+			t.Errorf(expectedOverriddenHeaderMsg, capturedHeaders[defaultHeaderName])
+		}
+	})
+}
+
+func TestReadChangesMethodHeaderHandling(t *testing.T) {
+	const readChangesResponse = `{"changes": [], "continuation_token": ""}`
+
+	t.Run("ReadChangesWithCustomHeaders", func(t *testing.T) {
+		var capturedHeaders map[string]string
+		server := createTestServer(t, &capturedHeaders, readChangesResponse)
+		defer server.Close()
+
+		client := createTestClient(t, server.URL, map[string]string{
+			defaultHeaderName: defaultHeaderValue,
+		})
+
+		_, err := client.ReadChanges(context.Background()).
+			Body(fgaSdkClient.ClientReadChangesRequest{
+				Type: "document",
+			}).
+			Options(fgaSdkClient.ClientReadChangesOptions{
+				RequestOptions: fgaSdkClient.RequestOptions{
+					Headers: map[string]string{
+						customHeaderName:  customHeaderValue,
+						defaultHeaderName: overriddenValue,
+					},
+				},
+			}).
+			Execute()
+
+		if err != nil {
+			t.Fatalf(checkRequestFailedMsg, err)
+		}
+
+		if capturedHeaders[customHeaderName] != customHeaderValue {
+			t.Errorf(expectedCustomHeaderMsg, capturedHeaders[customHeaderName])
+		}
+
+		if capturedHeaders[defaultHeaderName] != overriddenValue {
+			t.Errorf(expectedOverriddenHeaderMsg, capturedHeaders[defaultHeaderName])
+		}
+	})
+}
+
+func TestAssertionsMethodHeaderHandling(t *testing.T) {
+	t.Run("ReadAssertionsWithCustomHeaders", func(t *testing.T) {
+		const readAssertionsResponse = `{"assertions": []}`
+		var capturedHeaders map[string]string
+		server := createTestServer(t, &capturedHeaders, readAssertionsResponse)
+		defer server.Close()
+
+		client := createTestClient(t, server.URL, map[string]string{
+			defaultHeaderName: defaultHeaderValue,
+		})
+
+		_, err := client.ReadAssertions(context.Background()).
+			Options(fgaSdkClient.ClientReadAssertionsOptions{
+				RequestOptions: fgaSdkClient.RequestOptions{
+					Headers: map[string]string{
+						customHeaderName:  customHeaderValue,
+						defaultHeaderName: overriddenValue,
+					},
+				},
+				AuthorizationModelId: fgaSdk.PtrString("01H0H015178Y2V4CX10C2KGHF4"),
+			}).
+			Execute()
+
+		if err != nil {
+			t.Fatalf(checkRequestFailedMsg, err)
+		}
+
+		if capturedHeaders[customHeaderName] != customHeaderValue {
+			t.Errorf(expectedCustomHeaderMsg, capturedHeaders[customHeaderName])
+		}
+
+		if capturedHeaders[defaultHeaderName] != overriddenValue {
+			t.Errorf(expectedOverriddenHeaderMsg, capturedHeaders[defaultHeaderName])
+		}
+	})
+
+	t.Run("WriteAssertionsWithCustomHeaders", func(t *testing.T) {
+		const writeAssertionsResponse = `{}`
+		var capturedHeaders map[string]string
+		server := createTestServer(t, &capturedHeaders, writeAssertionsResponse)
+		defer server.Close()
+
+		client := createTestClient(t, server.URL, map[string]string{
+			defaultHeaderName: defaultHeaderValue,
+		})
+
+		assertions := []fgaSdkClient.ClientAssertion{
+			{
+				User:        testUser,
+				Relation:    testRelation,
+				Object:      testObject,
+				Expectation: true,
+			},
+		}
+
+		_, err := client.WriteAssertions(context.Background()).
+			Body(assertions).
+			Options(fgaSdkClient.ClientWriteAssertionsOptions{
+				RequestOptions: fgaSdkClient.RequestOptions{
+					Headers: map[string]string{
+						customHeaderName:  customHeaderValue,
+						defaultHeaderName: overriddenValue,
+					},
+				},
+				AuthorizationModelId: fgaSdk.PtrString("01H0H015178Y2V4CX10C2KGHF4"),
+			}).
+			Execute()
+
+		if err != nil {
+			t.Fatalf(checkRequestFailedMsg, err)
+		}
+
+		if capturedHeaders[customHeaderName] != customHeaderValue {
+			t.Errorf(expectedCustomHeaderMsg, capturedHeaders[customHeaderName])
+		}
+
+		if capturedHeaders[defaultHeaderName] != overriddenValue {
+			t.Errorf(expectedOverriddenHeaderMsg, capturedHeaders[defaultHeaderName])
+		}
+	})
+}

--- a/example/example1/example1.go
+++ b/example/example1/example1.go
@@ -254,6 +254,24 @@ func mainInner() error {
 	}
 	fmt.Printf("Allowed: %v\n", checkResponse.Allowed)
 
+	fmt.Println("Checking for access with custom headers")
+	checkWithHeadersResponse, err := fgaClient.Check(ctx).Body(client.ClientCheckRequest{
+		User:     "user:anne",
+		Relation: "viewer",
+		Object:   "document:0192ab2a-d83f-756d-9397-c5ed9f3cb69a",
+		Context:  &map[string]interface{}{"ViewCount": 100},
+	}).Options(client.ClientCheckOptions{
+		RequestOptions: client.RequestOptions{
+			Headers: map[string]string{
+				"X-Request-ID": "example-request-123",
+			},
+		},
+	}).Execute()
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Allowed (with custom headers): %v\n", checkWithHeadersResponse.Allowed)
+
 	// BatchCheck
 	fmt.Println("Batch checking for access")
 	batchCheckResponse, err := fgaClient.BatchCheck(ctx).Body(client.ClientBatchCheckRequest{


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

This PR adds support for sending custom headers per request.

It is complete, however it's kept in draft as it will have many conflicts with the other Go SDK PRs that will need to be resolved once the others are merged.

#### What problem is being solved?

#### How is it being solved?

#### What changes are made to solve it?

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

addresses go sdk part of https://github.com/openfga/sdk-generator/issues/569

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected

