### PR TITLE
feat(telemetry): add fga-client.request.count metric for tracking HTT…

### DIFF
--- a/api_executor.go
+++ b/api_executor.go
@@ -360,6 +360,8 @@ func (e *apiExecutor) recordTelemetry(operationName string, storeID string, body
 		attemptNum,
 	)
 
+	_, _ = metrics.RequestCount(1, attrs)
+
 	if requestDuration > 0 {
 		_, _ = metrics.RequestDuration(requestDuration, attrs)
 	}

--- a/telemetry/attributes.go
+++ b/telemetry/attributes.go
@@ -62,6 +62,12 @@ func (m *Metrics) PrepareAttributes(metric MetricInterface, attrs map[*Attribute
 		}
 
 		allowed = config.METRIC_COUNTER_CREDENTIALS_REQUEST
+	case METRIC_COUNTER_REQUEST_COUNT:
+		if config.METRIC_COUNTER_REQUEST_COUNT == nil {
+			return *attribute.EmptySet(), nil
+		}
+
+		allowed = config.METRIC_COUNTER_REQUEST_COUNT
 	case METRIC_HISTOGRAM_REQUEST_DURATION:
 		if config.METRIC_HISTOGRAM_REQUEST_DURATION == nil {
 			return *attribute.EmptySet(), nil

--- a/telemetry/configuration.go
+++ b/telemetry/configuration.go
@@ -25,6 +25,7 @@ type MetricConfiguration struct {
 
 type MetricsConfiguration struct {
 	METRIC_COUNTER_CREDENTIALS_REQUEST     *MetricConfiguration `json:"fga_client_credentials_request,omitempty"`
+	METRIC_COUNTER_REQUEST_COUNT           *MetricConfiguration `json:"fga_client_request_count,omitempty"`
 	METRIC_HISTOGRAM_REQUEST_DURATION      *MetricConfiguration `json:"fga_client_request_duration,omitempty"`
 	METRIC_HISTOGRAM_QUERY_DURATION        *MetricConfiguration `json:"fga_client_query_duration,omitempty"`
 	METRIC_HISTOGRAM_HTTP_REQUEST_DURATION *MetricConfiguration `json:"fga_client_http_request_duration,omitempty"`
@@ -38,6 +39,20 @@ func DefaultTelemetryConfiguration() *Configuration {
 	return &Configuration{
 		Metrics: &MetricsConfiguration{
 			METRIC_COUNTER_CREDENTIALS_REQUEST: &MetricConfiguration{
+				ATTR_FGA_CLIENT_REQUEST_CLIENT_ID:        &AttributeConfiguration{Enabled: true},
+				ATTR_HTTP_REQUEST_METHOD:                 &AttributeConfiguration{Enabled: true},
+				ATTR_FGA_CLIENT_REQUEST_MODEL_ID:         &AttributeConfiguration{Enabled: true},
+				ATTR_FGA_CLIENT_REQUEST_STORE_ID:         &AttributeConfiguration{Enabled: true},
+				ATTR_FGA_CLIENT_REQUEST_BATCH_CHECK_SIZE: &AttributeConfiguration{Enabled: false},
+				ATTR_FGA_CLIENT_RESPONSE_MODEL_ID:        &AttributeConfiguration{Enabled: true},
+				ATTR_HTTP_HOST:                           &AttributeConfiguration{Enabled: true},
+				ATTR_HTTP_REQUEST_RESEND_COUNT:           &AttributeConfiguration{Enabled: true},
+				ATTR_HTTP_RESPONSE_STATUS_CODE:           &AttributeConfiguration{Enabled: true},
+				ATTR_URL_FULL:                            &AttributeConfiguration{Enabled: true},
+				ATTR_URL_SCHEME:                          &AttributeConfiguration{Enabled: true},
+				ATTR_USER_AGENT_ORIGINAL:                 &AttributeConfiguration{Enabled: true},
+			},
+			METRIC_COUNTER_REQUEST_COUNT: &MetricConfiguration{
 				ATTR_FGA_CLIENT_REQUEST_CLIENT_ID:        &AttributeConfiguration{Enabled: true},
 				ATTR_HTTP_REQUEST_METHOD:                 &AttributeConfiguration{Enabled: true},
 				ATTR_FGA_CLIENT_REQUEST_MODEL_ID:         &AttributeConfiguration{Enabled: true},

--- a/telemetry/configuration_test.go
+++ b/telemetry/configuration_test.go
@@ -56,6 +56,7 @@ func TestDefaultTelemetryConfiguration(t *testing.T) {
 	}
 
 	testMetricConfiguration(config.Metrics.METRIC_COUNTER_CREDENTIALS_REQUEST, "METRIC_COUNTER_CREDENTIALS_REQUEST")
+	testMetricConfiguration(config.Metrics.METRIC_COUNTER_REQUEST_COUNT, "METRIC_COUNTER_REQUEST_COUNT")
 	testMetricConfiguration(config.Metrics.METRIC_HISTOGRAM_REQUEST_DURATION, "METRIC_HISTOGRAM_REQUEST_DURATION")
 	testMetricConfiguration(config.Metrics.METRIC_HISTOGRAM_QUERY_DURATION, "METRIC_HISTOGRAM_QUERY_DURATION")
 }

--- a/telemetry/counters.go
+++ b/telemetry/counters.go
@@ -2,9 +2,15 @@ package telemetry
 
 const (
 	METRIC_COUNTER_CREDENTIALS_REQUEST string = "fga-client.credentials.request"
+	METRIC_COUNTER_REQUEST_COUNT       string = "fga-client.request.count"
 )
 
 var CredentialsRequest = &Counter{
 	Name:        METRIC_COUNTER_CREDENTIALS_REQUEST,
 	Description: "The total number of times new access tokens have been requested using ClientCredentials.",
+}
+
+var RequestCount = &Counter{
+	Name:        METRIC_COUNTER_REQUEST_COUNT,
+	Description: "The total number of HTTP requests made by the SDK.",
 }

--- a/telemetry/counters_test.go
+++ b/telemetry/counters_test.go
@@ -20,3 +20,20 @@ func TestCredentialsRequestCounter(t *testing.T) {
 		t.Errorf("Expected Description to be '%s', but got '%s'", expectedDescription, CredentialsRequest.GetDescription())
 	}
 }
+
+func TestRequestCountCounter(t *testing.T) {
+	expectedName := METRIC_COUNTER_REQUEST_COUNT
+	expectedDescription := "The total number of HTTP requests made by the SDK."
+
+	if RequestCount == nil {
+		t.Fatalf("Expected RequestCount to be initialized, but got nil")
+	}
+
+	if RequestCount.GetName() != expectedName {
+		t.Errorf("Expected Name to be '%s', but got '%s'", expectedName, RequestCount.GetName())
+	}
+
+	if RequestCount.GetDescription() != expectedDescription {
+		t.Errorf("Expected Description to be '%s', but got '%s'", expectedDescription, RequestCount.GetDescription())
+	}
+}

--- a/telemetry/metrics.go
+++ b/telemetry/metrics.go
@@ -22,6 +22,7 @@ type MetricsInterface interface {
 	GetCounter(name string, description string) (metric.Int64Counter, error)
 	GetHistogram(name string, description string, unit string) (metric.Float64Histogram, error)
 	CredentialsRequest(value int64, attrs map[*Attribute]string) (metric.Int64Counter, error)
+	RequestCount(value int64, attrs map[*Attribute]string) (metric.Int64Counter, error)
 	RequestDuration(value float64, attrs map[*Attribute]string) (metric.Float64Histogram, error)
 	QueryDuration(value float64, attrs map[*Attribute]string) (metric.Float64Histogram, error)
 	HTTPRequestDuration(value float64, attrs map[*Attribute]string) (metric.Float64Histogram, error)
@@ -62,6 +63,20 @@ func (m *Metrics) CredentialsRequest(value int64, attrs map[*Attribute]string) (
 
 	if err == nil {
 		attrs, err := m.PrepareAttributes(CredentialsRequest, attrs, m.Configuration)
+
+		if err == nil {
+			counter.Add(context.Background(), value, metric.WithAttributeSet(attrs))
+		}
+	}
+
+	return counter, err
+}
+
+func (m *Metrics) RequestCount(value int64, attrs map[*Attribute]string) (metric.Int64Counter, error) {
+	var counter, err = m.GetCounter(RequestCount.Name, RequestCount.Description)
+
+	if err == nil {
+		attrs, err := m.PrepareAttributes(RequestCount, attrs, m.Configuration)
 
 		if err == nil {
 			counter.Add(context.Background(), value, metric.WithAttributeSet(attrs))

--- a/telemetry/metrics_test.go
+++ b/telemetry/metrics_test.go
@@ -204,6 +204,33 @@ func TestCredentialsRequest(t *testing.T) {
 	}
 }
 
+func TestRequestCount(t *testing.T) {
+	mockMeter := &MockMeter{
+		counters:   make(map[string]metric.Int64Counter),
+		histograms: make(map[string]metric.Float64Histogram),
+	}
+	metrics := &Metrics{
+		Meter:    mockMeter,
+		Counters: make(map[string]metric.Int64Counter),
+	}
+
+	attrs := make(map[*Attribute]string)
+
+	counter, err := metrics.RequestCount(1, attrs)
+	if err != nil {
+		t.Fatalf("Expected no error, but got %v", err)
+	}
+
+	if counter == nil {
+		t.Fatalf("Expected a non-nil counter, but got nil")
+	}
+
+	mockCounter, ok := counter.(*MockInt64Counter)
+	if !ok || !mockCounter.addCalled {
+		t.Fatalf("Expected Add method to be called on counter")
+	}
+}
+
 func TestRequestDuration(t *testing.T) {
 	mockMeter := &MockMeter{
 		counters:   make(map[string]metric.Int64Counter),

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -40,6 +40,12 @@ type QueryDurationMetricParameters struct {
 	TelemetryFactoryParameters
 }
 
+type RequestCountMetricParameters struct {
+	Value int64
+	Attrs map[*Attribute]string
+	TelemetryFactoryParameters
+}
+
 type TelemetryContextKey struct{}
 
 var (
@@ -110,6 +116,10 @@ func GetMetrics(factory TelemetryFactoryParameters) MetricsInterface {
 
 func CredentialsRequestMetric(factory CredentialsRequestMetricParameters) (metric.Int64Counter, error) {
 	return GetMetrics(TelemetryFactoryParameters{Configuration: factory.Configuration}).CredentialsRequest(factory.Value, factory.Attrs)
+}
+
+func RequestCountMetric(factory RequestCountMetricParameters) (metric.Int64Counter, error) {
+	return GetMetrics(TelemetryFactoryParameters{Configuration: factory.Configuration}).RequestCount(factory.Value, factory.Attrs)
 }
 
 func RequestDurationMetric(factory RequestDurationMetricParameters) (metric.Float64Histogram, error) {

--- a/telemetry/telemetry_test.go
+++ b/telemetry/telemetry_test.go
@@ -39,6 +39,11 @@ func (m *MockMetrics) CredentialsRequest(value int64, attrs map[*Attribute]strin
 	return counter, nil
 }
 
+func (m *MockMetrics) RequestCount(value int64, attrs map[*Attribute]string) (metric.Int64Counter, error) {
+	counter, _ := m.GetCounter("request_count", "A request count")
+	return counter, nil
+}
+
 func (m *MockMetrics) RequestDuration(value float64, attrs map[*Attribute]string) (metric.Float64Histogram, error) {
 	histogram, _ := m.GetHistogram("request_duration", "A request duration", "ms")
 	return histogram, nil
@@ -154,6 +159,31 @@ func TestCredentialsRequestMetric(t *testing.T) {
 	}
 
 	counter, err := CredentialsRequestMetric(factoryParams)
+	if err != nil {
+		t.Fatalf("Expected no error, but got %v", err)
+	}
+
+	if counter == nil {
+		t.Fatalf("Expected counter to be non-nil")
+	}
+}
+
+func TestRequestCountMetric(t *testing.T) {
+	config := &Configuration{}
+	metrics := &MockMetrics{
+		counters:   make(map[string]metric.Int64Counter),
+		histograms: make(map[string]metric.Float64Histogram),
+	}
+	telemetry := &Telemetry{Metrics: metrics, Configuration: config}
+	Bind(context.Background(), telemetry)
+
+	factoryParams := RequestCountMetricParameters{
+		Value:                      1,
+		Attrs:                      make(map[*Attribute]string),
+		TelemetryFactoryParameters: TelemetryFactoryParameters{Configuration: config},
+	}
+
+	counter, err := RequestCountMetric(factoryParams)
 	if err != nil {
 		t.Fatalf("Expected no error, but got %v", err)
 	}


### PR DESCRIPTION
…P requests

Record a counter metric on every HTTP attempt in recordTelemetry(), alongside the existing request.duration and query.duration metrics. This enables users to track the total number of HTTP requests made by the SDK via OpenTelemetry.

Closes #282

<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?

#### How is it being solved?

#### What changes are made to solve it?

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

