### PR TITLE
fix: do not retry non-retryable HTTP 4xx client errors

### DIFF
--- a/api_executor.go
+++ b/api_executor.go
@@ -481,6 +481,9 @@ func (e *apiExecutor) determineRetry(
 	// Check for rate limit or internal server errors that support retry
 	var rateLimitErr FgaApiRateLimitExceededError
 	var internalErr FgaApiInternalError
+	var validationErr FgaApiValidationError
+	var authErr FgaApiAuthenticationError
+	var notFoundErr FgaApiNotFoundError
 
 	switch {
 	case errors.As(err, &rateLimitErr):
@@ -489,6 +492,12 @@ func (e *apiExecutor) determineRetry(
 	case errors.As(err, &internalErr):
 		timeToWait := internalErr.GetTimeToWait(attemptNum, retryParams)
 		return timeToWait > 0, timeToWait
+	case errors.As(err, &validationErr):
+		return false, 0
+	case errors.As(err, &authErr):
+		return false, 0
+	case errors.As(err, &notFoundErr):
+		return false, 0
 	default:
 		// Network errors or body read errors
 		headers := http.Header{}

--- a/api_executor_test.go
+++ b/api_executor_test.go
@@ -813,6 +813,46 @@ func TestAPIExecutor_DetermineRetry(t *testing.T) {
 			expectShouldRetry:  false,
 			expectWaitDuration: false,
 		},
+		{
+			name:               "validation_error_no_retry",
+			err:                FgaApiValidationError{error: "validation error", responseStatusCode: 400},
+			response:           &APIExecutorResponse{StatusCode: 400, Headers: http.Header{}},
+			attemptNum:         0,
+			retryParams:        RetryParams{MaxRetry: 3, MinWaitInMs: 50},
+			operationName:      "Test",
+			expectShouldRetry:  false,
+			expectWaitDuration: false,
+		},
+		{
+			name:               "authentication_error_no_retry",
+			err:                FgaApiAuthenticationError{error: "auth error", responseStatusCode: 401},
+			response:           &APIExecutorResponse{StatusCode: 401, Headers: http.Header{}},
+			attemptNum:         0,
+			retryParams:        RetryParams{MaxRetry: 3, MinWaitInMs: 50},
+			operationName:      "Test",
+			expectShouldRetry:  false,
+			expectWaitDuration: false,
+		},
+		{
+			name:               "authentication_error_403_no_retry",
+			err:                FgaApiAuthenticationError{error: "forbidden", responseStatusCode: 403},
+			response:           &APIExecutorResponse{StatusCode: 403, Headers: http.Header{}},
+			attemptNum:         0,
+			retryParams:        RetryParams{MaxRetry: 3, MinWaitInMs: 50},
+			operationName:      "Test",
+			expectShouldRetry:  false,
+			expectWaitDuration: false,
+		},
+		{
+			name:               "not_found_error_no_retry",
+			err:                FgaApiNotFoundError{error: "not found", responseStatusCode: 404},
+			response:           &APIExecutorResponse{StatusCode: 404, Headers: http.Header{}},
+			attemptNum:         0,
+			retryParams:        RetryParams{MaxRetry: 3, MinWaitInMs: 50},
+			operationName:      "Test",
+			expectShouldRetry:  false,
+			expectWaitDuration: false,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -2107,26 +2147,17 @@ func TestAPIExecutor_ExecuteStreaming_ExhaustsRetriesOnPersistentServerError(t *
 	assert.Equal(t, 3, attemptCount, "expected 3 attempts (1 initial + 2 retries)")
 }
 
-func TestAPIExecutor_ExecuteStreaming_RetriesOnNonSpecificHTTPErrors(t *testing.T) {
-	// 400 errors fall through to determineRetry's default case, which retries them
-	// just like the non-streaming executeInternal path. This test verifies that
-	// streaming matches the same behavior as non-streaming endpoints.
+func TestAPIExecutor_ExecuteStreaming_DoesNotRetryValidationErrors(t *testing.T) {
+	// 400 validation errors are not retryable — they fail immediately without retries.
 	t.Parallel()
 
 	attemptCount := 0
 	client := newTestClient(t, &testRoundTripper{fn: func(req *http.Request) (*http.Response, error) {
 		attemptCount++
-		if attemptCount <= 2 {
-			return &http.Response{
-				StatusCode: 400,
-				Body:       io.NopCloser(strings.NewReader(`{"code":"validation_error","message":"Invalid request"}`)),
-				Header:     http.Header{"Content-Type": []string{"application/json"}},
-			}, nil
-		}
 		return &http.Response{
-			StatusCode: 200,
-			Body:       io.NopCloser(strings.NewReader(`{"result":{"object":"doc:1"}}` + "\n")),
-			Header:     http.Header{},
+			StatusCode: 400,
+			Body:       io.NopCloser(strings.NewReader(`{"code":"validation_error","message":"Invalid request"}`)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
 		}, nil
 	}}, &RetryParams{MaxRetry: 3, MinWaitInMs: 1})
 
@@ -2140,17 +2171,9 @@ func TestAPIExecutor_ExecuteStreaming_RetriesOnNonSpecificHTTPErrors(t *testing.
 		Body:           map[string]string{"type": "document"},
 	}, 10)
 
-	require.NoError(t, err)
-	require.NotNil(t, channel)
-	defer channel.Close()
-
-	var results [][]byte
-	for result := range channel.Results {
-		results = append(results, result)
-	}
-
-	assert.Equal(t, 3, attemptCount, "400 errors are retried via default case, matching non-streaming behavior")
-	assert.Len(t, results, 1)
+	assert.Error(t, err)
+	assert.Nil(t, channel)
+	assert.Equal(t, 1, attemptCount, "400 validation errors should not be retried")
 }
 
 func TestAPIExecutor_ExecuteStreaming_DoesNotRetryContextCancellation(t *testing.T) {

--- a/api_open_fga_test.go
+++ b/api_open_fga_test.go
@@ -2406,9 +2406,8 @@ func TestStreamedListObjectsExecute(t *testing.T) {
 		}
 	})
 
-	t.Run("retry on 400 validation error via default case", func(t *testing.T) {
-		// Note: 400 errors fall through to determineRetry's default case, which retries
-		// them just like the non-streaming Check endpoint does. This is consistent behavior.
+	t.Run("no retry on 400 validation error", func(t *testing.T) {
+		// 400 validation errors are not retryable — they fail immediately.
 		var attempts int32
 
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -2443,13 +2442,13 @@ func TestStreamedListObjectsExecute(t *testing.T) {
 			if channel != nil {
 				channel.Close()
 			}
-			t.Fatal("expected error for persistent 400 responses, got nil")
+			t.Fatal("expected error for 400 response, got nil")
 		}
 
 		gotAttempts := int(atomic.LoadInt32(&attempts))
-		// 400 errors are retried via the default case in determineRetry (matching non-streaming behavior)
-		if gotAttempts != 3 {
-			t.Fatalf("expected 3 attempts (1 initial + 2 retries, matching non-streaming behavior), got %d", gotAttempts)
+		// 400 errors should not be retried
+		if gotAttempts != 1 {
+			t.Fatalf("expected 1 attempt (no retries for validation errors), got %d", gotAttempts)
 		}
 	})
 


### PR DESCRIPTION
Previously, determineRetry only handled 429 (rate limit) and 5xx (server errors) explicitly. All other errors — including 400 (validation), 401/403 (authentication), and 404 (not found) — fell into the default case which retried them with exponential backoff.
HTTP 4xx errors (except 429) are client errors where the request is invalid and resending it will always produce the same result. They should never be retried.

<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
Part of https://github.com/openfga/cli/issues/677
Once this is merged we can bump the go SDK version in the CLI and release
#### What problem is being solved?

#### How is it being solved?

#### What changes are made to solve it?

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API error handling to prevent unnecessary retries for validation errors (400), authentication errors (401, 403), and not-found errors (404). These errors now fail immediately instead of attempting retries, reducing latency for requests that cannot succeed.

* **Tests**
  * Enhanced test coverage for error retry behavior to validate non-retryable error scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openfga/go-sdk/pull/319?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->