### PR TITLE
chore: bump Go toolchain to go1.25.11 and golangci-lint to v2.12.2

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -72,7 +72,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:
-          version: v2.12.1
+          version: v2.12.2
 
   govulncheck:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
   hooks:
     - id: gitleaks
 - repo: https://github.com/golangci/golangci-lint
-  rev: v2.12.1
+  rev: v2.12.2
   hooks:
     - id: golangci-lint
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/example/api_executor/go.mod
+++ b/example/api_executor/go.mod
@@ -2,7 +2,7 @@ module api_executor
 
 go 1.25.0
 
-toolchain go1.25.4
+toolchain go1.25.11
 
 require github.com/openfga/go-sdk v0.7.5
 

--- a/example/api_executor/go.mod
+++ b/example/api_executor/go.mod
@@ -2,7 +2,7 @@ module api_executor
 
 go 1.25.0
 
-toolchain go1.25.11
+toolchain go1.26.4
 
 require github.com/openfga/go-sdk v0.7.5
 

--- a/example/example1/go.mod
+++ b/example/example1/go.mod
@@ -2,7 +2,7 @@ module example1
 
 go 1.25.0
 
-toolchain go1.25.4
+toolchain go1.25.11
 
 // To reference published build, comment below and run `go mod tidy`
 replace github.com/openfga/go-sdk v0.7.5 => ../../

--- a/example/example1/go.mod
+++ b/example/example1/go.mod
@@ -2,7 +2,7 @@ module example1
 
 go 1.25.0
 
-toolchain go1.25.11
+toolchain go1.26.4
 
 // To reference published build, comment below and run `go mod tidy`
 replace github.com/openfga/go-sdk v0.7.5 => ../../

--- a/example/opentelemetry/go.mod
+++ b/example/opentelemetry/go.mod
@@ -2,7 +2,7 @@ module openfga-opentelemetry-example
 
 go 1.25.0
 
-toolchain go1.25.4
+toolchain go1.25.11
 
 // To reference published build, comment below and run `go mod tidy`
 replace github.com/openfga/go-sdk v0.7.5 => ../../

--- a/example/opentelemetry/go.mod
+++ b/example/opentelemetry/go.mod
@@ -2,7 +2,7 @@ module openfga-opentelemetry-example
 
 go 1.25.0
 
-toolchain go1.25.11
+toolchain go1.26.4
 
 // To reference published build, comment below and run `go mod tidy`
 replace github.com/openfga/go-sdk v0.7.5 => ../../

--- a/example/streamed_list_objects/go.mod
+++ b/example/streamed_list_objects/go.mod
@@ -2,7 +2,7 @@ module streamed_list_objects
 
 go 1.25.0
 
-toolchain go1.25.4
+toolchain go1.25.11
 
 require (
 	github.com/openfga/go-sdk v0.7.5

--- a/example/streamed_list_objects/go.mod
+++ b/example/streamed_list_objects/go.mod
@@ -2,7 +2,7 @@ module streamed_list_objects
 
 go 1.25.0
 
-toolchain go1.25.11
+toolchain go1.26.4
 
 require (
 	github.com/openfga/go-sdk v0.7.5

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/openfga/go-sdk
 
 go 1.25.0
 
-toolchain go1.25.4
+toolchain go1.25.11
 
 require (
 	github.com/jarcoal/httpmock v1.4.1

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/openfga/go-sdk
 
 go 1.25.0
 
-toolchain go1.25.11
+toolchain go1.26.4
 
 require (
 	github.com/jarcoal/httpmock v1.4.1


### PR DESCRIPTION
Bumps Go toolchain from `go1.25.4` to `go1.25.11` and golangci-lint from `v2.12.1` to `v2.12.2`.

Also updates `.pre-commit-config.yaml` to align the pre-commit golangci-lint hook version with CI (`v2.12.2`), ensuring contributors run the same linter version locally as in CI.