### PR TITLE
chore: upgrade Go toolchain to 1.26.5

### DIFF
--- a/example/api_executor/go.mod
+++ b/example/api_executor/go.mod
@@ -2,7 +2,7 @@ module api_executor
 
 go 1.25.0
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require github.com/openfga/go-sdk v0.7.5
 

--- a/example/example1/go.mod
+++ b/example/example1/go.mod
@@ -2,7 +2,7 @@ module example1
 
 go 1.25.0
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 // To reference published build, comment below and run `go mod tidy`
 replace github.com/openfga/go-sdk v0.7.5 => ../../

--- a/example/opentelemetry/go.mod
+++ b/example/opentelemetry/go.mod
@@ -2,7 +2,7 @@ module openfga-opentelemetry-example
 
 go 1.25.0
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 // To reference published build, comment below and run `go mod tidy`
 replace github.com/openfga/go-sdk v0.7.5 => ../../

--- a/example/streamed_list_objects/go.mod
+++ b/example/streamed_list_objects/go.mod
@@ -2,7 +2,7 @@ module streamed_list_objects
 
 go 1.25.0
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/openfga/go-sdk v0.7.5

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/openfga/go-sdk
 
 go 1.25.0
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/jarcoal/httpmock v1.4.1


### PR DESCRIPTION
  ## Summary

  Bumps the Go **toolchain** to `go1.26.5` across the module and all example
  submodules. This is a toolchain-only hygiene bump — the `go` compatibility
  floor stays at `1.25.0` so downstream consumers on the previous Go minor
  continue to build.

  Per the repo's own contributor convention
  (`.claude/rules/pr-conventions.md`):
  > Go version policy: support latest + latest-1 per Go's release policy.
  > Target `(latest-1).0` in `go.mod` but use latest for `toolchain`.

  ## Changes

  `toolchain go1.26.4 → go1.26.5` in each `go.mod` (5 files):

  - `go.mod`
  - `example/api_executor/go.mod`
  - `example/example1/go.mod`
  - `example/opentelemetry/go.mod`
  - `example/streamed_list_objects/go.mod`

  The `go 1.25.0` directive (compat floor) is intentionally left untouched in
  every module.

  ## Not changed (already at latest)

  - **golangci-lint** — pinned at `2.12.2` (workflow `version:`, `.pre-commit-config.yaml` hook `rev:`)
  - **golangci-lint-action** — pinned at `v9.3.0` (`ba0d7d2…`)
  - CI resolves the Go version via `setup-go` with `go-version-file: ./go.mod`,
    so no workflow edit is needed for the toolchain bump.

  ## Verification

  - `go mod tidy` — zero module churn (no `go.sum` changes)
  - `make lint` (golangci-lint 2.12.2, built with go1.26.5) — **0 issues**
  - `make test` (`go test -race ./...`) — **all packages pass**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the project and example applications to use Go toolchain version 1.26.5.
  - Improved consistency across the repository’s build environments.
  - Preserved existing module settings and example behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->